### PR TITLE
Added: installation set-input-parameters

### DIFF
--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -19,7 +19,7 @@ func NewInstallationsCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCreateCommand(ctx))
-	cmd.AddCommand(NewSetInputParametersCommand(ctx))
+	cmd.AddCommand(NewSetImportParametersCommand(ctx))
 
 	return cmd
 }

--- a/cmd/installations/installations.go
+++ b/cmd/installations/installations.go
@@ -19,6 +19,7 @@ func NewInstallationsCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCreateCommand(ctx))
+	cmd.AddCommand(NewSetInputParametersCommand(ctx))
 
 	return cmd
 }

--- a/cmd/installations/set_input_parameters.go
+++ b/cmd/installations/set_input_parameters.go
@@ -13,9 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/yaml"
 
-	"github.com/gardener/landscapercli/pkg/logger"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+
+	"github.com/gardener/landscapercli/pkg/logger"
 )
 
 type inputParametersOptions struct {
@@ -25,11 +26,11 @@ type inputParametersOptions struct {
 	inputParameters map[string]string
 }
 
-//NewSetInputParametersCommand sets input parameters from an installation to hardcoded values (as importDataMappings)
-func NewSetInputParametersCommand(ctx context.Context) *cobra.Command {
+//NewSetImportParametersCommand sets input parameters from an installation to hardcoded values (as importDataMappings)
+func NewSetImportParametersCommand(ctx context.Context) *cobra.Command {
 	opts := &inputParametersOptions{}
 	cmd := &cobra.Command{
-		Use:     "set-input-parameters",
+		Use:     "set-import-parameters",
 		Aliases: []string{"sip"},
 		Short:   "set import parameters for an installation. Enquote string values in double quotation marks.",
 		Example: "landscapercli installation set-input-parameters <path-to-installation>.yaml importName1=\"string-value\" importName2=42",
@@ -87,7 +88,7 @@ func replaceImportsWithInputParameters(installation *lsv1alpha1.Installation, o 
 	//find all imports.data that are specified in inputParameters
 	for _, importData := range installation.Spec.Imports.Data {
 		if inputParameter, ok := o.inputParameters[importData.Name]; ok {
-			validImportDataMappings[importData.Name] = json.RawMessage(fmt.Sprintf(`%s`, inputParameter))
+			validImportDataMappings[importData.Name] = json.RawMessage(inputParameter)
 		}
 	}
 

--- a/cmd/installations/set_input_parameters.go
+++ b/cmd/installations/set_input_parameters.go
@@ -1,0 +1,120 @@
+package installations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/gardener/landscaper/pkg/kubernetes"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/yaml"
+
+	"github.com/gardener/landscapercli/pkg/logger"
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+)
+
+type inputParametersOptions struct {
+	installationPath string
+
+	//input parameters that should be used for the import values
+	inputParameters map[string]string
+}
+
+//NewSetInputParametersCommand sets input parameters from an installation to hardcoded values (as importDataMappings)
+func NewSetInputParametersCommand(ctx context.Context) *cobra.Command {
+	opts := &inputParametersOptions{}
+	cmd := &cobra.Command{
+		Use:     "set-input-parameters",
+		Aliases: []string{"sip"},
+		Short:   "set import parameters for an installation. Enquote string values in double quotation marks.",
+		Example: "landscapercli installation set-input-parameters <path-to-installation>.yaml importName1=\"string-value\" importName2=42",
+		Args:    cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opts.validateArguments(args); err != nil {
+				cmd.PrintErr(err.Error())
+				os.Exit(1)
+			}
+
+			if err := opts.run(ctx, logger.Log, cmd); err != nil {
+				cmd.PrintErr(err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+	cmd.SetOut(os.Stdout)
+
+	return cmd
+}
+
+func (o *inputParametersOptions) validateArguments(args []string) error {
+	o.installationPath = args[0]
+
+	o.inputParameters = make(map[string]string)
+	for _, v := range args[1:] {
+		keyValue := strings.SplitN(v, "=", 2)
+		o.inputParameters[keyValue[0]] = keyValue[1]
+	}
+	return nil
+}
+
+func (o *inputParametersOptions) run(ctx context.Context, log logr.Logger, cmd *cobra.Command) error {
+	installation := lsv1alpha1.Installation{}
+
+	err := readInstallationFromFile(o, &installation)
+	if err != nil {
+		return err
+	}
+
+	replaceImportsWithInputParameters(&installation, o)
+
+	marshaledYaml, err := yaml.Marshal(installation)
+	if err != nil {
+		return fmt.Errorf("cannot marshal yaml: %w\nDid you enquote the value if it is a string?", err)
+	}
+	cmd.Println(string(marshaledYaml))
+
+	return nil
+}
+
+func replaceImportsWithInputParameters(installation *lsv1alpha1.Installation, o *inputParametersOptions) {
+	validImportDataMappings := make(map[string]json.RawMessage)
+
+	//find all imports.data that are specified in inputParameters
+	for _, importData := range installation.Spec.Imports.Data {
+		if inputParameter, ok := o.inputParameters[importData.Name]; ok {
+			validImportDataMappings[importData.Name] = json.RawMessage(fmt.Sprintf(`%s`, inputParameter))
+		}
+	}
+
+	//modify the installation
+	for importName, importDataMappingValue := range validImportDataMappings {
+		if installation.Spec.ImportDataMappings == nil {
+			installation.Spec.ImportDataMappings = make(map[string]json.RawMessage)
+		}
+		//add to importDataMappings
+		installation.Spec.ImportDataMappings[importName] = importDataMappingValue
+
+		//remove from imports.data
+		for i, importData := range installation.Spec.Imports.Data {
+			if importData.Name == importName {
+				installation.Spec.Imports.Data = append(installation.Spec.Imports.Data[:i], installation.Spec.Imports.Data[i+1:]...)
+			}
+		}
+	}
+}
+
+func readInstallationFromFile(o *inputParametersOptions, installation *lsv1alpha1.Installation) error {
+	installationFileData, err := ioutil.ReadFile(o.installationPath)
+	if err != nil {
+		return err
+	}
+	if _, _, err := serializer.NewCodecFactory(kubernetes.LandscaperScheme).UniversalDecoder().Decode(installationFileData, nil, installation); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/installations/set_input_parameters_test.go
+++ b/cmd/installations/set_input_parameters_test.go
@@ -1,0 +1,86 @@
+package installations
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestImportParameterFilling(t *testing.T) {
+	installation := lsv1alpha1.Installation{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: lsv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "Installation",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sampleinstallation",
+		},
+		Spec: lsv1alpha1.InstallationSpec{
+			ComponentDescriptor: &lsv1alpha1.ComponentDescriptorDefinition{
+				Reference: &lsv1alpha1.ComponentDescriptorReference{
+					RepositoryContext: &cdv2.RepositoryContext{
+						Type:    cdv2.OCIRegistryType,
+						BaseURL: "sample.cluster.local",
+					},
+					ComponentName: "component name",
+					Version:       "v0.0.1",
+				},
+			},
+			Blueprint: lsv1alpha1.BlueprintDefinition{
+				Reference: &lsv1alpha1.RemoteBlueprintReference{
+					ResourceName: "blueprintressourcename",
+				},
+			},
+			Imports: lsv1alpha1.InstallationImports{
+				Data: []lsv1alpha1.DataImport{
+					{
+						Name: "intValue",
+					},
+					{
+						Name: "floatValue",
+					},
+					{
+						Name: "stringValue",
+					},
+					{
+						Name: "stringValueWithSpace",
+					},
+				},
+			},
+		},
+	}
+
+	inputParameters := map[string]string{
+		"intValue":             "10",
+		"floatValue":           "10.1",
+		"stringValue":          "\"testValue\"",
+		"stringValueWithSpace": "\"test Value\"",
+	}
+
+	replaceImportsWithInputParameters(&installation, &inputParametersOptions{inputParameters: inputParameters})
+
+	t.Run("String replacements", func(t *testing.T) {
+		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["stringValue"])), installation.Spec.ImportDataMappings["stringValue"])
+		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["stringValueWithSpace"])), installation.Spec.ImportDataMappings["stringValueWithSpace"])
+	})
+	t.Run("Number replacements", func(t *testing.T) {
+		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["intValue"])), installation.Spec.ImportDataMappings["intValue"])
+		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["floatValue"])), installation.Spec.ImportDataMappings["floatValue"])
+	})
+	t.Run("Correct removing of imports.data and adding to importDataMapping list", func(t *testing.T) {
+		assert.Equal(t, 4, len(installation.Spec.ImportDataMappings))
+		assert.Equal(t, 0, len(installation.Spec.Imports.Data))
+	})
+	t.Run("Marshaling of yaml", func(t *testing.T) {
+		_, err := yaml.Marshal(installation)
+		assert.Nil(t, err)
+	})
+
+}

--- a/cmd/installations/set_input_parameters_test.go
+++ b/cmd/installations/set_input_parameters_test.go
@@ -2,7 +2,6 @@ package installations
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
@@ -67,12 +66,12 @@ func TestImportParameterFilling(t *testing.T) {
 	replaceImportsWithInputParameters(&installation, &inputParametersOptions{inputParameters: inputParameters})
 
 	t.Run("String replacements", func(t *testing.T) {
-		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["stringValue"])), installation.Spec.ImportDataMappings["stringValue"])
-		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["stringValueWithSpace"])), installation.Spec.ImportDataMappings["stringValueWithSpace"])
+		assert.Equal(t, json.RawMessage(inputParameters["stringValue"]), installation.Spec.ImportDataMappings["stringValue"])
+		assert.Equal(t, json.RawMessage(inputParameters["stringValueWithSpace"]), installation.Spec.ImportDataMappings["stringValueWithSpace"])
 	})
 	t.Run("Number replacements", func(t *testing.T) {
-		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["intValue"])), installation.Spec.ImportDataMappings["intValue"])
-		assert.Equal(t, json.RawMessage(fmt.Sprintf(`%s`, inputParameters["floatValue"])), installation.Spec.ImportDataMappings["floatValue"])
+		assert.Equal(t, json.RawMessage(inputParameters["intValue"]), installation.Spec.ImportDataMappings["intValue"])
+		assert.Equal(t, json.RawMessage(inputParameters["floatValue"]), installation.Spec.ImportDataMappings["floatValue"])
 	})
 	t.Run("Correct removing of imports.data and adding to importDataMapping list", func(t *testing.T) {
 		assert.Equal(t, 4, len(installation.Spec.ImportDataMappings))


### PR DESCRIPTION
**What this PR does / why we need it**:
Added: installation set-input-parameters

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
installation set-input-parameters command to set static values for imports
```
