### PR TITLE
Added: create installation and set-import parameters file output

### DIFF
--- a/cmd/installations/create.go
+++ b/cmd/installations/create.go
@@ -189,11 +189,11 @@ func (o *createOpts) run(ctx context.Context, cmd *cobra.Command, log logr.Logge
 	} else {
 		f, err := os.Create(o.outputPath)
 		if err != nil {
-			return fmt.Errorf("Error creating file %s:%w", o.outputPath, err)
+			return fmt.Errorf("error creating file %s: %w", o.outputPath, err)
 		}
 		_, err = f.Write(marshaledYaml)
 		if err != nil {
-			return fmt.Errorf("Error writing file %s:%w", o.outputPath, err)
+			return fmt.Errorf("error writing file %s: %w", o.outputPath, err)
 		}
 	}
 
@@ -340,7 +340,7 @@ func (o *createOpts) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.name, "name", "my-installation", "name of the installation")
 	fs.BoolVar(&o.renderSchemaInfo, "render-schema-info", true, "render schema information of the component's imports and exports as comments into the installation")
 	fs.StringVar(&o.blueprintResourceName, "blueprint-resource-name", "", "name of the blueprint resource in the component descriptor (optional if only one blueprint resource is specified in the component descriptor)")
-	fs.StringVarP(&o.outputPath, "output", "o", "", "file path for the resulting installation yaml")
+	fs.StringVarP(&o.outputPath, "output-file", "o", "", "file path for the resulting installation yaml")
 	o.OciOptions.AddFlags(fs)
 }
 

--- a/cmd/installations/create.go
+++ b/cmd/installations/create.go
@@ -191,7 +191,10 @@ func (o *createOpts) run(ctx context.Context, cmd *cobra.Command, log logr.Logge
 		if err != nil {
 			return fmt.Errorf("Error creating file %s:%w", o.outputPath, err)
 		}
-		f.Write(marshaledYaml)
+		_, err = f.Write(marshaledYaml)
+		if err != nil {
+			return fmt.Errorf("Error writing file %s:%w", o.outputPath, err)
+		}
 	}
 
 	return nil

--- a/cmd/installations/create.go
+++ b/cmd/installations/create.go
@@ -41,6 +41,9 @@ type createOpts struct {
 	// OciOptions contains all exposed options to configure the oci client.
 	OciOptions ociopts.Options
 
+	//outputPath is the path to write the installation.yaml to
+	outputPath string
+
 	// name of the blueprint resource in the component descriptor (optional if only one blueprint resource is specified in the component descriptor)
 	blueprintResourceName string
 	name                  string
@@ -181,7 +184,15 @@ func (o *createOpts) run(ctx context.Context, cmd *cobra.Command, log logr.Logge
 		}
 	}
 
-	cmd.Println(string(marshaledYaml))
+	if o.outputPath == "" {
+		cmd.Println(string(marshaledYaml))
+	} else {
+		f, err := os.Create(o.outputPath)
+		if err != nil {
+			return fmt.Errorf("Error creating file %s:%w", o.outputPath, err)
+		}
+		f.Write(marshaledYaml)
+	}
 
 	return nil
 }
@@ -326,6 +337,7 @@ func (o *createOpts) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.name, "name", "my-installation", "name of the installation")
 	fs.BoolVar(&o.renderSchemaInfo, "render-schema-info", true, "render schema information of the component's imports and exports as comments into the installation")
 	fs.StringVar(&o.blueprintResourceName, "blueprint-resource-name", "", "name of the blueprint resource in the component descriptor (optional if only one blueprint resource is specified in the component descriptor)")
+	fs.StringVarP(&o.outputPath, "output", "o", "", "file path for the resulting installation yaml")
 	o.OciOptions.AddFlags(fs)
 }
 

--- a/cmd/installations/set_import_parameters.go
+++ b/cmd/installations/set_import_parameters.go
@@ -83,7 +83,7 @@ func (o *inputParametersOptions) run(ctx context.Context, log logr.Logger, cmd *
 
 	err = replaceImportsWithInputParameters(&installation, o)
 	if err != nil {
-		return fmt.Errorf("Error setting the import parameters: %w", err)
+		return fmt.Errorf("error setting the import parameters: %w", err)
 	}
 
 	marshaledYaml, err := yaml.Marshal(installation)
@@ -96,17 +96,17 @@ func (o *inputParametersOptions) run(ctx context.Context, log logr.Logger, cmd *
 	}
 	f, err := os.Create(outputPath)
 	if err != nil {
-		return fmt.Errorf("Error creating file %s:%w", outputPath, err)
+		return fmt.Errorf("error creating file %s: %w", outputPath, err)
 	}
 	_, err = f.Write(marshaledYaml)
 	if err != nil {
-		return fmt.Errorf("Error writing file %s:%w", outputPath, err)
+		return fmt.Errorf("error writing file %s: %w", outputPath, err)
 	}
 	return nil
 }
 
 func (o *inputParametersOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVarP(&o.outputPath, "output", "o", "", "file path for the resulting installation yaml (default: overwrite the given installation file)")
+	fs.StringVarP(&o.outputPath, "output-file", "o", "", "file path for the resulting installation yaml (default: overwrite the given installation file)")
 }
 
 func replaceImportsWithInputParameters(installation *lsv1alpha1.Installation, o *inputParametersOptions) error {

--- a/cmd/installations/set_import_parameters.go
+++ b/cmd/installations/set_import_parameters.go
@@ -122,7 +122,7 @@ func replaceImportsWithInputParameters(installation *lsv1alpha1.Installation, o 
 	//check for any not used importParameters
 	for k := range o.importParameters {
 		if _, ok := validImportDataMappings[k]; !ok {
-			return fmt.Errorf(`import parameter '%s' not found in the blueprint`, k)
+			return fmt.Errorf(`import parameter '%s' not found in the installation`, k)
 		}
 	}
 

--- a/cmd/installations/set_import_parameters.go
+++ b/cmd/installations/set_import_parameters.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gardener/landscapercli/pkg/logger"
 )
 
-type inputParametersOptions struct {
+type importParametersOptions struct {
 	installationPath string
 
 	//input parameters that should be used for the import values
@@ -33,7 +33,7 @@ type inputParametersOptions struct {
 
 //NewSetImportParametersCommand sets input parameters from an installation to hardcoded values (as importDataMappings)
 func NewSetImportParametersCommand(ctx context.Context) *cobra.Command {
-	opts := &inputParametersOptions{}
+	opts := &importParametersOptions{}
 	cmd := &cobra.Command{
 		Use:     "set-import-parameters",
 		Aliases: []string{"sip"},
@@ -59,7 +59,7 @@ func NewSetImportParametersCommand(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-func (o *inputParametersOptions) validateArguments(args []string) error {
+func (o *importParametersOptions) validateArguments(args []string) error {
 	o.installationPath = args[0]
 
 	o.importParameters = make(map[string]string)
@@ -73,7 +73,7 @@ func (o *inputParametersOptions) validateArguments(args []string) error {
 	return nil
 }
 
-func (o *inputParametersOptions) run(ctx context.Context, log logr.Logger, cmd *cobra.Command) error {
+func (o *importParametersOptions) run(ctx context.Context, log logr.Logger, cmd *cobra.Command) error {
 	installation := lsv1alpha1.Installation{}
 
 	err := readInstallationFromFile(o, &installation)
@@ -81,7 +81,7 @@ func (o *inputParametersOptions) run(ctx context.Context, log logr.Logger, cmd *
 		return err
 	}
 
-	err = replaceImportsWithInputParameters(&installation, o)
+	err = replaceImportsWithImportParameters(&installation, o)
 	if err != nil {
 		return fmt.Errorf("error setting the import parameters: %w", err)
 	}
@@ -105,11 +105,11 @@ func (o *inputParametersOptions) run(ctx context.Context, log logr.Logger, cmd *
 	return nil
 }
 
-func (o *inputParametersOptions) AddFlags(fs *pflag.FlagSet) {
+func (o *importParametersOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.outputPath, "output-file", "o", "", "file path for the resulting installation yaml (default: overwrite the given installation file)")
 }
 
-func replaceImportsWithInputParameters(installation *lsv1alpha1.Installation, o *inputParametersOptions) error {
+func replaceImportsWithImportParameters(installation *lsv1alpha1.Installation, o *importParametersOptions) error {
 	validImportDataMappings := make(map[string]json.RawMessage)
 
 	//find all imports.data that are specified in importParameters
@@ -153,7 +153,7 @@ func createJSONRawMessageValueWithStringOrNumericType(parameter string) json.Raw
 
 }
 
-func readInstallationFromFile(o *inputParametersOptions, installation *lsv1alpha1.Installation) error {
+func readInstallationFromFile(o *importParametersOptions, installation *lsv1alpha1.Installation) error {
 	installationFileData, err := ioutil.ReadFile(o.installationPath)
 	if err != nil {
 		return err

--- a/cmd/installations/set_import_parameters_test.go
+++ b/cmd/installations/set_import_parameters_test.go
@@ -63,7 +63,8 @@ func TestImportParameterFilling(t *testing.T) {
 		"stringValueWithSpace": "test Value",
 	}
 
-	replaceImportsWithInputParameters(&installation, &inputParametersOptions{importParameters: inputParameters})
+	err := replaceImportsWithInputParameters(&installation, &inputParametersOptions{importParameters: inputParameters})
+	assert.Nil(t, err)
 
 	t.Run("String replacements", func(t *testing.T) {
 		assert.Equal(t, json.RawMessage(`"testValue"`), installation.Spec.ImportDataMappings["stringValue"])

--- a/cmd/installations/set_import_parameters_test.go
+++ b/cmd/installations/set_import_parameters_test.go
@@ -56,14 +56,14 @@ func TestImportParameterFilling(t *testing.T) {
 		},
 	}
 
-	inputParameters := map[string]string{
+	importParameters := map[string]string{
 		"intValue":             "10",
 		"floatValue":           "10.1",
 		"stringValue":          "testValue",
 		"stringValueWithSpace": "test Value",
 	}
 
-	err := replaceImportsWithInputParameters(&installation, &inputParametersOptions{importParameters: inputParameters})
+	err := replaceImportsWithImportParameters(&installation, &importParametersOptions{importParameters: importParameters})
 	assert.Nil(t, err)
 
 	t.Run("String replacements", func(t *testing.T) {
@@ -71,8 +71,8 @@ func TestImportParameterFilling(t *testing.T) {
 		assert.Equal(t, json.RawMessage(`"test Value"`), installation.Spec.ImportDataMappings["stringValueWithSpace"])
 	})
 	t.Run("Number replacements", func(t *testing.T) {
-		assert.Equal(t, json.RawMessage(inputParameters["intValue"]), installation.Spec.ImportDataMappings["intValue"])
-		assert.Equal(t, json.RawMessage(inputParameters["floatValue"]), installation.Spec.ImportDataMappings["floatValue"])
+		assert.Equal(t, json.RawMessage(importParameters["intValue"]), installation.Spec.ImportDataMappings["intValue"])
+		assert.Equal(t, json.RawMessage(importParameters["floatValue"]), installation.Spec.ImportDataMappings["floatValue"])
 	})
 	t.Run("Correct removing of imports.data and adding to importDataMapping list", func(t *testing.T) {
 		assert.Equal(t, 4, len(installation.Spec.ImportDataMappings))

--- a/docs/reference/landscaper-cli_installations_create.md
+++ b/docs/reference/landscaper-cli_installations_create.md
@@ -20,6 +20,7 @@ landscaper-cli installations create my-registry:5000 github.com/my-component v0.
       --cc-config string                 path to the local concourse config file
   -h, --help                             help for create
       --name string                      name of the installation (default "my-installation")
+  -o, --output string                    file path for the resulting installation yaml
       --registry-config string           path to the dockerconfig.json with the oci registry authentication information
       --render-schema-info               render schema information of the component's imports and exports as comments into the installation (default true)
 ```

--- a/docs/reference/landscaper-cli_installations_create.md
+++ b/docs/reference/landscaper-cli_installations_create.md
@@ -20,7 +20,7 @@ landscaper-cli installations create my-registry:5000 github.com/my-component v0.
       --cc-config string                 path to the local concourse config file
   -h, --help                             help for create
       --name string                      name of the installation (default "my-installation")
-  -o, --output string                    file path for the resulting installation yaml
+  -o, --output-file string               file path for the resulting installation yaml
       --registry-config string           path to the dockerconfig.json with the oci registry authentication information
       --render-schema-info               render schema information of the component's imports and exports as comments into the installation (default true)
 ```

--- a/docs/reference/landscaper-cli_installations_set-import-parameters.md
+++ b/docs/reference/landscaper-cli_installations_set-import-parameters.md
@@ -15,7 +15,8 @@ landscaper-cli installations set-import-parameters <path-to-installation>.yaml i
 ### Options
 
 ```
-  -h, --help   help for set-import-parameters
+  -h, --help            help for set-import-parameters
+  -o, --output string   file path for the resulting installation yaml (default: overwrite the given installation file)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/landscaper-cli_installations_set-import-parameters.md
+++ b/docs/reference/landscaper-cli_installations_set-import-parameters.md
@@ -15,8 +15,8 @@ landscaper-cli installations set-import-parameters <path-to-installation>.yaml i
 ### Options
 
 ```
-  -h, --help            help for set-import-parameters
-  -o, --output string   file path for the resulting installation yaml (default: overwrite the given installation file)
+  -h, --help                 help for set-import-parameters
+  -o, --output-file string   file path for the resulting installation yaml (default: overwrite the given installation file)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
**What this PR does / why we need it**:
Added: create installation and set-import parameters file output
set-import-parameters now tells the user if a given import parameter is not found in a blueprint

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
