### PR TITLE
add import validation in the render command

### DIFF
--- a/cmd/blueprints/testdata/00-render/imports.yaml
+++ b/cmd/blueprints/testdata/00-render/imports.yaml
@@ -5,4 +5,6 @@ imports:
     metadata:
       name: my-target
       namespace: test
+    spec:
+      type: example.com/my-type
   imp1: first-value

--- a/cmd/blueprints/types.go
+++ b/cmd/blueprints/types.go
@@ -14,7 +14,7 @@ type Values struct {
 }
 
 // ValidateValues validates values file.
-func ValidateValues(values *Values) error {
+func ValidateValues(values Values) error {
 	allErrs := field.ErrorList{}
 
 	fldPath := field.NewPath("imports")

--- a/docs/reference/landscaper-cli_blueprints_render.md
+++ b/docs/reference/landscaper-cli_blueprints_render.md
@@ -31,10 +31,13 @@ landscaper-cli blueprints render [path to Blueprint directory] [all,deployitems,
 
 ```
   -a, --additional-component-descriptor stringArray   Path to additional local component descriptors
+      --allow-plain-http                              allows the fallback to http if the oci registry does not support https
+      --cc-config string                              path to the local concourse config file
   -c, --component-descriptor string                   Path to the local component descriptor
   -f, --file stringArray                              List of filepaths to value yaml files that define the imports
   -h, --help                                          help for render
   -o, --output string                                 The format of the output. Can be json or yaml. (default "yaml")
+      --registry-config string                        path to the dockerconfig.json with the oci registry authentication information
   -w, --write string                                  The output directory where the rendered files should be written to
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #47

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The imports that are specified for the render command are now validated.
This also enables developers to test jsonschema definitions.
```
