### PR TITLE
always use last repo context in installations create cmd

### DIFF
--- a/cmd/installations/create.go
+++ b/cmd/installations/create.go
@@ -407,7 +407,7 @@ func buildInstallation(name string, cd *cdv2.ComponentDescriptor, blueprintRes c
 		Spec: lsv1alpha1.InstallationSpec{
 			ComponentDescriptor: &lsv1alpha1.ComponentDescriptorDefinition{
 				Reference: &lsv1alpha1.ComponentDescriptorReference{
-					RepositoryContext: &cd.RepositoryContexts[0],
+					RepositoryContext: &cd.RepositoryContexts[len(cd.RepositoryContexts)-1],
 					ComponentName:     cd.ObjectMeta.Name,
 					Version:           cd.ObjectMeta.Version,
 				},

--- a/cmd/installations/create_test.go
+++ b/cmd/installations/create_test.go
@@ -1,0 +1,161 @@
+package installations
+
+import (
+	"testing"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildInstallation(t *testing.T) {
+	tests := []struct {
+		name                 string
+		cd                   *cdv2.ComponentDescriptor
+		expectedInstallation *lsv1alpha1.Installation
+	}{
+		{
+			name: "test with single repo context",
+			cd: &cdv2.ComponentDescriptor{
+				ComponentSpec: cdv2.ComponentSpec{
+					RepositoryContexts: []cdv2.RepositoryContext{
+						{
+							Type:    "ociRegistry",
+							BaseURL: "first-registry.com",
+						},
+					},
+				},
+			},
+			expectedInstallation: &lsv1alpha1.Installation{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Installation",
+					APIVersion: lsv1alpha1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-installation",
+				},
+				Spec: lsv1alpha1.InstallationSpec{
+					ComponentDescriptor: &lsv1alpha1.ComponentDescriptorDefinition{
+						Reference: &lsv1alpha1.ComponentDescriptorReference{
+							RepositoryContext: &cdv2.RepositoryContext{
+								Type:    "ociRegistry",
+								BaseURL: "first-registry.com",
+							},
+						},
+					},
+					Blueprint: lsv1alpha1.BlueprintDefinition{
+						Reference: &lsv1alpha1.RemoteBlueprintReference{
+							ResourceName: "blueprint-res",
+						},
+					},
+					Imports: lsv1alpha1.InstallationImports{
+						Targets: []lsv1alpha1.TargetImportExport{
+							{
+								Name:   "test-target",
+								Target: "",
+							},
+						},
+						Data: []lsv1alpha1.DataImport{
+							{
+								Name: "test-data-import",
+							},
+						},
+					},
+					Exports: lsv1alpha1.InstallationExports{
+						Targets: []lsv1alpha1.TargetImportExport{},
+						Data:    []lsv1alpha1.DataExport{},
+					},
+				},
+			},
+		},
+		{
+			name: "use latest repo context if multiple repo contexts exist",
+			cd: &cdv2.ComponentDescriptor{
+				ComponentSpec: cdv2.ComponentSpec{
+					RepositoryContexts: []cdv2.RepositoryContext{
+						{
+							Type:    "ociRegistry",
+							BaseURL: "first-registry.com",
+						},
+						{
+							Type:    "ociRegistry",
+							BaseURL: "second-registry.com",
+						},
+					},
+				},
+			},
+			expectedInstallation: &lsv1alpha1.Installation{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Installation",
+					APIVersion: lsv1alpha1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-installation",
+				},
+				Spec: lsv1alpha1.InstallationSpec{
+					ComponentDescriptor: &lsv1alpha1.ComponentDescriptorDefinition{
+						Reference: &lsv1alpha1.ComponentDescriptorReference{
+							RepositoryContext: &cdv2.RepositoryContext{
+								Type:    "ociRegistry",
+								BaseURL: "second-registry.com",
+							},
+						},
+					},
+					Blueprint: lsv1alpha1.BlueprintDefinition{
+						Reference: &lsv1alpha1.RemoteBlueprintReference{
+							ResourceName: "blueprint-res",
+						},
+					},
+					Imports: lsv1alpha1.InstallationImports{
+						Targets: []lsv1alpha1.TargetImportExport{
+							{
+								Name: "test-target",
+							},
+						},
+						Data: []lsv1alpha1.DataImport{
+							{
+								Name: "test-data-import",
+							},
+						},
+					},
+					Exports: lsv1alpha1.InstallationExports{
+						Targets: []lsv1alpha1.TargetImportExport{},
+						Data:    []lsv1alpha1.DataExport{},
+					},
+				},
+			},
+		},
+	}
+
+	blueprint := &lsv1alpha1.Blueprint{
+		Imports: lsv1alpha1.ImportDefinitionList{
+			{
+				FieldValueDefinition: lsv1alpha1.FieldValueDefinition{
+					Name:       "test-target",
+					TargetType: string(lsv1alpha1.KubernetesClusterTargetType),
+				},
+			},
+			{
+				FieldValueDefinition: lsv1alpha1.FieldValueDefinition{
+					Name: "test-data-import",
+				},
+			},
+		},
+	}
+
+	blueprintResource := cdv2.Resource{
+		IdentityObjectMeta: cdv2.IdentityObjectMeta{
+			Name: "blueprint-res",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			installation := buildInstallation("test-installation", tt.cd, blueprintResource, blueprint)
+			assert.Equal(t, tt.expectedInstallation, installation)
+		})
+	}
+
+}

--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -287,8 +287,11 @@ landscaper:
 `
 
 	tmpFile, err := ioutil.TempFile(".", "landscaper-values-")
+	if err != nil {
+		return fmt.Errorf("cannot create temporary file: %w", err)
+	}
 	defer func() {
-		err = os.Remove(tmpFile.Name())
+		err := os.Remove(tmpFile.Name())
 		if err != nil {
 			fmt.Printf("Cannot remove temporary file %s: %s", tmpFile.Name(), err.Error())
 		}

--- a/pkg/util/cmd.go
+++ b/pkg/util/cmd.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// ExecCommandBlocking executes a command and wait for its completion.  Returns a Cmd that can be used to stop the command
+// ExecCommandBlocking executes a command and wait for its completion.
 func ExecCommandBlocking(command string) error {
 	fmt.Printf("Executing: %s\n", command)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
use the last repository context in the "installations create" cmd

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- use the last repository context in the "installations create" cmd
```
