### PR TITLE
allow old and new blueprint resource types in util method

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	lscore "github.com/gardener/landscaper/apis/core"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -318,7 +319,7 @@ func BuildKubernetesClusterTarget(name, namespace, kubeconfigPath string) (*lsv1
 func GetBlueprintResource(cd *cdv2.ComponentDescriptor, blueprintResourceName string) (*cdv2.Resource, error) {
 	blueprintResources := map[string]cdv2.Resource{}
 	for _, resource := range cd.ComponentSpec.Resources {
-		if resource.IdentityObjectMeta.Type == lsv1alpha1.BlueprintResourceType || resource.IdentityObjectMeta.Type == lsv1alpha1.OldBlueprintType {
+		if resource.IdentityObjectMeta.Type == lscore.BlueprintType || resource.IdentityObjectMeta.Type == lscore.OldBlueprintType {
 			blueprintResources[resource.Name] = resource
 		}
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
-	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	lscore "github.com/gardener/landscaper/apis/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +26,7 @@ func TestGetBlueprintResource(t *testing.T) {
 							IdentityObjectMeta: cdv2.IdentityObjectMeta{
 								Name:    "my-blueprint",
 								Version: "v0.1.0",
-								Type:    lsv1alpha1.BlueprintResourceType,
+								Type:    lscore.BlueprintType,
 							},
 						},
 					},
@@ -37,7 +37,31 @@ func TestGetBlueprintResource(t *testing.T) {
 				IdentityObjectMeta: cdv2.IdentityObjectMeta{
 					Name:    "my-blueprint",
 					Version: "v0.1.0",
-					Type:    lsv1alpha1.BlueprintResourceType,
+					Type:    lscore.BlueprintType,
+				},
+			},
+		},
+		{
+			name: "old blueprint type",
+			cd: &cdv2.ComponentDescriptor{
+				ComponentSpec: cdv2.ComponentSpec{
+					Resources: []cdv2.Resource{
+						{
+							IdentityObjectMeta: cdv2.IdentityObjectMeta{
+								Name:    "my-blueprint",
+								Version: "v0.1.0",
+								Type:    lscore.OldBlueprintType,
+							},
+						},
+					},
+				},
+			},
+			resourceName: "",
+			expectedResource: &cdv2.Resource{
+				IdentityObjectMeta: cdv2.IdentityObjectMeta{
+					Name:    "my-blueprint",
+					Version: "v0.1.0",
+					Type:    lscore.OldBlueprintType,
 				},
 			},
 		},
@@ -50,14 +74,14 @@ func TestGetBlueprintResource(t *testing.T) {
 							IdentityObjectMeta: cdv2.IdentityObjectMeta{
 								Name:    "my-blueprint",
 								Version: "v0.1.0",
-								Type:    lsv1alpha1.BlueprintResourceType,
+								Type:    lscore.BlueprintType,
 							},
 						},
 						{
 							IdentityObjectMeta: cdv2.IdentityObjectMeta{
 								Name:    "my-blueprint-2",
 								Version: "v0.1.0",
-								Type:    lsv1alpha1.BlueprintResourceType,
+								Type:    lscore.BlueprintType,
 							},
 						},
 					},
@@ -68,7 +92,7 @@ func TestGetBlueprintResource(t *testing.T) {
 				IdentityObjectMeta: cdv2.IdentityObjectMeta{
 					Name:    "my-blueprint",
 					Version: "v0.1.0",
-					Type:    lsv1alpha1.BlueprintResourceType,
+					Type:    lscore.BlueprintType,
 				},
 			},
 		},
@@ -81,14 +105,14 @@ func TestGetBlueprintResource(t *testing.T) {
 							IdentityObjectMeta: cdv2.IdentityObjectMeta{
 								Name:    "my-blueprint",
 								Version: "v0.1.0",
-								Type:    lsv1alpha1.BlueprintResourceType,
+								Type:    lscore.BlueprintType,
 							},
 						},
 						{
 							IdentityObjectMeta: cdv2.IdentityObjectMeta{
 								Name:    "my-blueprint-2",
 								Version: "v0.1.0",
-								Type:    lsv1alpha1.BlueprintResourceType,
+								Type:    lscore.BlueprintType,
 							},
 						},
 					},
@@ -106,14 +130,14 @@ func TestGetBlueprintResource(t *testing.T) {
 							IdentityObjectMeta: cdv2.IdentityObjectMeta{
 								Name:    "my-blueprint",
 								Version: "v0.1.0",
-								Type:    lsv1alpha1.BlueprintResourceType,
+								Type:    lscore.BlueprintType,
 							},
 						},
 						{
 							IdentityObjectMeta: cdv2.IdentityObjectMeta{
 								Name:    "my-blueprint-2",
 								Version: "v0.1.0",
-								Type:    lsv1alpha1.BlueprintResourceType,
+								Type:    lscore.BlueprintType,
 							},
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
allow both old and new blueprint resource types in util method (referenced in "installations create")

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- "installations create" now works for both the old and new blueprint resource types (referenced in the component descriptor)
```
