### PR TITLE
Fix integration test

### DIFF
--- a/integration-test/tests/test_installations_create.go
+++ b/integration-test/tests/test_installations_create.go
@@ -306,6 +306,10 @@ func (t *installationsCreateTest) checkInstallation(outBuf *bytes.Buffer) error 
 		return fmt.Errorf("cannot unmarshal cmd output into installation: %w", err)
 	}
 
+	// exclude raw fields from check, because the order of fields can vary
+	expectedInstallation.Spec.ComponentDescriptor.Reference.RepositoryContext.Raw = nil
+	actualInstallation.Spec.ComponentDescriptor.Reference.RepositoryContext.Raw = nil
+
 	ok := assert.Equal(inttestutil.DummyTestingT{}, expectedInstallation, actualInstallation)
 	if !ok {
 		return fmt.Errorf("expected installation does not match with actual installation")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the integration test of the landscaper cli. Currently, the test fails, because the repository context of an installation is not as expected.  However, the difference is just the field order in the raw yaml representation. The parsed objects are equal. The fix excludes the raw yaml from the check and only compares the objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
