### PR TITLE
Render with relative paths

### DIFF
--- a/cmd/blueprints/render.go
+++ b/cmd/blueprints/render.go
@@ -224,7 +224,23 @@ func (o *RenderOptions) setupImports(fs vfs.FileSystem, args *lsutils.BlueprintR
 }
 
 func (o *RenderOptions) Complete(log logr.Logger, args []string, fs vfs.FileSystem) error {
-	o.BlueprintPath = args[0]
+	if len(o.ValueFiles) > 0 {
+		for i := range o.ValueFiles{
+			absPath, err := filepath.Abs(o.ValueFiles[i])
+			if err != nil {
+				return fmt.Errorf("unable get absolute values file path for %s: %w", o.ValueFiles[i], err)
+			}
+			o.ValueFiles[i] = absPath
+		}
+	}
+
+	absBlueprintPath, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("unable get absolute blueprint path for %s: %w", args[0], err)
+	}
+
+	o.BlueprintPath = absBlueprintPath
+
 	data, err := vfs.ReadFile(fs, filepath.Join(o.BlueprintPath, lsv1alpha1.BlueprintFileName))
 	if err != nil {
 		return fmt.Errorf("unable to read blueprint from %s: %w", filepath.Join(o.BlueprintPath, lsv1alpha1.BlueprintFileName), err)
@@ -239,6 +255,13 @@ func (o *RenderOptions) Complete(log logr.Logger, args []string, fs vfs.FileSyst
 	}
 
 	if len(o.ComponentDescriptorPath) != 0 {
+		absComponentDescriptorPath, err := filepath.Abs(o.ComponentDescriptorPath)
+		if err != nil {
+			return fmt.Errorf("unable get absolute component descriptor path for %s: %w", o.ComponentDescriptorPath, err)
+		}
+
+		o.ComponentDescriptorPath = absComponentDescriptorPath
+
 		data, err := vfs.ReadFile(fs, o.ComponentDescriptorPath)
 		if err != nil {
 			return fmt.Errorf("unable to read component descriptor from %s: %w", o.ComponentDescriptorPath, err)

--- a/cmd/blueprints/render.go
+++ b/cmd/blueprints/render.go
@@ -225,7 +225,7 @@ func (o *RenderOptions) setupImports(fs vfs.FileSystem, args *lsutils.BlueprintR
 
 func (o *RenderOptions) Complete(log logr.Logger, args []string, fs vfs.FileSystem) error {
 	if len(o.ValueFiles) > 0 {
-		for i := range o.ValueFiles{
+		for i := range o.ValueFiles {
 			absPath, err := filepath.Abs(o.ValueFiles[i])
 			if err != nil {
 				return fmt.Errorf("unable get absolute values file path for %s: %w", o.ValueFiles[i], err)

--- a/cmd/blueprints/render_test.go
+++ b/cmd/blueprints/render_test.go
@@ -28,17 +28,17 @@ func TestRenderCommandWithComponentDescriptor(t *testing.T) {
 	fail := failFunc(a)
 	assertNestedString := assertNestedStringFunc(a)
 
-	testdataFs, err := createTestdataFs("./testdata/00-render")
+	testdataFs, err := createTestdataFs(".")
 	fail(a.NoError(err))
 	renderOpts := &blueprints.RenderOptions{
-		ComponentDescriptorPath: "./component-descriptor.yaml",
-		ValueFiles:              []string{"./imports.yaml"},
+		ComponentDescriptorPath: "./testdata/00-render/component-descriptor.yaml",
+		ValueFiles:              []string{"./testdata/00-render/imports.yaml"},
 		OutDir:                  "./out",
 		OutputFormat:            blueprints.YAMLOut,
 	}
 
-	a.NoError(renderOpts.Complete(logr.Discard(), []string{"./blueprint"}, testdataFs))
-	fail(a.Equal("./blueprint", renderOpts.BlueprintPath))
+	a.NoError(renderOpts.Complete(logr.Discard(), []string{"./testdata/00-render/blueprint"}, testdataFs))
+	fail(a.Equal("./testdata/00-render/blueprint", renderOpts.BlueprintPath))
 	fail(a.NoError(renderOpts.Run(context.TODO(), logr.Discard(), testdataFs)))
 
 	renderedFiles, err := vfs.ReadDir(testdataFs, filepath.Join(renderOpts.OutDir, blueprints.DeployItemOutputDir))

--- a/cmd/blueprints/render_test.go
+++ b/cmd/blueprints/render_test.go
@@ -28,7 +28,7 @@ func TestRenderCommandWithComponentDescriptor(t *testing.T) {
 	fail := failFunc(a)
 	assertNestedString := assertNestedStringFunc(a)
 
-	testdataFs, err := createTestdataFs(".")
+	testdataFs, err := createTestdataFs("/")
 	fail(a.NoError(err))
 	renderOpts := &blueprints.RenderOptions{
 		ComponentDescriptorPath: "./testdata/00-render/component-descriptor.yaml",
@@ -38,7 +38,9 @@ func TestRenderCommandWithComponentDescriptor(t *testing.T) {
 	}
 
 	a.NoError(renderOpts.Complete(logr.Discard(), []string{"./testdata/00-render/blueprint"}, testdataFs))
-	fail(a.Equal("./testdata/00-render/blueprint", renderOpts.BlueprintPath))
+
+	absBlueprintPath, _ := filepath.Abs("./testdata/00-render/blueprint")
+	fail(a.Equal(absBlueprintPath, renderOpts.BlueprintPath))
 	fail(a.NoError(renderOpts.Run(context.TODO(), logr.Discard(), testdataFs)))
 
 	renderedFiles, err := vfs.ReadDir(testdataFs, filepath.Join(renderOpts.OutDir, blueprints.DeployItemOutputDir))
@@ -65,16 +67,18 @@ func TestRenderCommandWithDefaults(t *testing.T) {
 	fail := failFunc(a)
 	assertNestedString := assertNestedStringFunc(a)
 
-	testdataFs, err := createTestdataFs("./testdata/00-render")
+	testdataFs, err := createTestdataFs("/")
 	fail(a.NoError(err))
 	renderOpts := &blueprints.RenderOptions{
-		ValueFiles:   []string{"./imports.yaml"},
+		ValueFiles:   []string{"./testdata/00-render/imports.yaml"},
 		OutDir:       "./out",
 		OutputFormat: blueprints.YAMLOut,
 	}
 
-	a.NoError(renderOpts.Complete(logr.Discard(), []string{"./blueprint"}, testdataFs))
-	fail(a.Equal("./blueprint", renderOpts.BlueprintPath))
+	a.NoError(renderOpts.Complete(logr.Discard(), []string{"./testdata/00-render/blueprint"}, testdataFs))
+
+	absBlueprintFilePath, _ := filepath.Abs("./testdata/00-render/blueprint")
+	fail(a.Equal(absBlueprintFilePath, renderOpts.BlueprintPath))
 	fail(a.NoError(renderOpts.Run(context.TODO(), logr.Discard(), testdataFs)))
 
 	renderedFiles, err := vfs.ReadDir(testdataFs, filepath.Join(renderOpts.OutDir, blueprints.DeployItemOutputDir))
@@ -102,11 +106,13 @@ func TestImportValidationOfRenderCommand(t *testing.T) {
 		a := assert.New(t)
 		fail := failFunc(a)
 
-		testdataFs, err := createTestdataFs("./testdata/00-render")
+		testdataFs, err := createTestdataFs("/")
 		fail(a.NoError(err))
+
+		absValuePath, _ := filepath.Abs("./testdata/00-render/imports.yaml")
 		renderOpts := &blueprints.RenderOptions{
-			ComponentDescriptorPath: "./component-descriptor.yaml",
-			ValueFiles:              []string{"./imports.yaml"},
+			ComponentDescriptorPath: "./testdata/00-render/component-descriptor.yaml",
+			ValueFiles:              []string{absValuePath},
 			OutDir:                  "./out",
 			OutputFormat:            blueprints.YAMLOut,
 		}
@@ -124,8 +130,9 @@ imports:
 `
 		fail(a.NoError(vfs.WriteFile(testdataFs, renderOpts.ValueFiles[0], []byte(importData), os.ModePerm)))
 
-		a.NoError(renderOpts.Complete(logr.Discard(), []string{"./blueprint"}, testdataFs))
-		fail(a.Equal("./blueprint", renderOpts.BlueprintPath))
+		a.NoError(renderOpts.Complete(logr.Discard(), []string{"./testdata/00-render/blueprint"}, testdataFs))
+		absBlueprintPath, _ := filepath.Abs("./testdata/00-render/blueprint")
+		fail(a.Equal(absBlueprintPath, renderOpts.BlueprintPath))
 		fail(a.Error(renderOpts.Run(context.TODO(), logr.Discard(), testdataFs)))
 	})
 
@@ -133,11 +140,12 @@ imports:
 		a := assert.New(t)
 		fail := failFunc(a)
 
-		testdataFs, err := createTestdataFs("./testdata/00-render")
+		testdataFs, err := createTestdataFs("/")
 		fail(a.NoError(err))
+		absValuePath, _ := filepath.Abs("./testdata/00-render/imports.yaml")
 		renderOpts := &blueprints.RenderOptions{
-			ComponentDescriptorPath: "./component-descriptor.yaml",
-			ValueFiles:              []string{"./imports.yaml"},
+			ComponentDescriptorPath: "./testdata/00-render/component-descriptor.yaml",
+			ValueFiles:              []string{absValuePath},
 			OutDir:                  "./out",
 			OutputFormat:            blueprints.YAMLOut,
 		}
@@ -155,8 +163,9 @@ imports:
 `
 		fail(a.NoError(vfs.WriteFile(testdataFs, renderOpts.ValueFiles[0], []byte(importData), os.ModePerm)))
 
-		a.NoError(renderOpts.Complete(logr.Discard(), []string{"./blueprint"}, testdataFs))
-		fail(a.Equal("./blueprint", renderOpts.BlueprintPath))
+		a.NoError(renderOpts.Complete(logr.Discard(), []string{"./testdata/00-render/blueprint"}, testdataFs))
+		absBlueprintPath, _ := filepath.Abs("./testdata/00-render/blueprint")
+		fail(a.Equal(absBlueprintPath, renderOpts.BlueprintPath))
 		fail(a.Error(renderOpts.Run(context.TODO(), logr.Discard(), testdataFs)))
 	})
 
@@ -164,10 +173,10 @@ imports:
 		a := assert.New(t)
 		fail := failFunc(a)
 
-		testdataFs, err := createTestdataFs("./testdata/00-render")
+		testdataFs, err := createTestdataFs("/")
 		fail(a.NoError(err))
 		renderOpts := &blueprints.RenderOptions{
-			ComponentDescriptorPath: "./component-descriptor.yaml",
+			ComponentDescriptorPath: "./testdata/00-render/component-descriptor.yaml",
 			ValueFiles:              []string{"./imports.yaml"},
 			OutDir:                  "./out",
 			OutputFormat:            blueprints.YAMLOut,
@@ -185,8 +194,9 @@ imports:
 `
 		fail(a.NoError(vfs.WriteFile(testdataFs, renderOpts.ValueFiles[0], []byte(importData), os.ModePerm)))
 
-		a.NoError(renderOpts.Complete(logr.Discard(), []string{"./blueprint"}, testdataFs))
-		fail(a.Equal("./blueprint", renderOpts.BlueprintPath))
+		a.NoError(renderOpts.Complete(logr.Discard(), []string{"./testdata/00-render/blueprint"}, testdataFs))
+		absBlueprintPath, _ := filepath.Abs("./testdata/00-render/blueprint")
+		fail(a.Equal(absBlueprintPath, renderOpts.BlueprintPath))
 		fail(a.Error(renderOpts.Run(context.TODO(), logr.Discard(), testdataFs)))
 	})
 

--- a/docs/commands/create_component/create.md
+++ b/docs/commands/create_component/create.md
@@ -276,7 +276,7 @@ In a first step, we add the resources in file *[resources.yaml](resources/04-ste
 to the component descriptor with the following command:
 
 ```shell script
-landscaper-cli components-cli component-archive resources add \
+landscaper-cli component-cli component-archive resources add \
    $LS_COMPONENT_DIR/demo-component \
    $LS_COMPONENT_DIR/demo-component/resources.yaml
 ```
@@ -337,7 +337,7 @@ Note that you must adjust the base URL of the OCI registry.
 If your OCI registry requires authentication, see [login-to-oci-registry](../../login-to-oci-registry.md).
 
 ```shell script
-landscaper-cli components-cli ca remote push \
+landscaper-cli component-cli ca remote push \
     eu.gcr.io/<some-path> \
     github.com/gardener/landscapercli/nginx \
     v0.1.0 \
@@ -373,7 +373,7 @@ kubectl port-forward -n <namespace of OCI registry> oci-registry-<pod-id> 5000:5
 Then you could upload the component via:
 
 ```shell script
-landscaper-cli components-cli ca remote push \
+landscaper-cli component-cli ca remote push \
     localhost:5000 \
     github.com/gardener/landscapercli/nginx \
     v0.1.0 \

--- a/docs/examples/component-descriptor-blueprint/README.md
+++ b/docs/examples/component-descriptor-blueprint/README.md
@@ -25,7 +25,7 @@ landscaper-cli blueprints push localhost:5000/echo-server-blueprint:v0.1.0 ./com
 
 5. Upload Component Descriptor to the OCI registry
 ```
-landscaper-cli components-cli remote push localhost:5000/components github.com/gardener/echo-server-cd v0.1.0 ./component-descriptor-blueprint
+landscaper-cli component-cli remote push localhost:5000/components github.com/gardener/echo-server-cd v0.1.0 ./component-descriptor-blueprint
 ```
 
 6. Apply the target to your cluster

--- a/integration-test/tests/test_installations_create.go
+++ b/integration-test/tests/test_installations_create.go
@@ -470,7 +470,7 @@ access:
 
 	err = cmdPush.Execute()
 	if err != nil {
-		return fmt.Errorf("components-cli component-archive remote push failed: %w", err)
+		return fmt.Errorf("component-cli component-archive remote push failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows calling the render command with arguments containing relative paths.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- render command could be called with relative paths
```
