### PR TITLE
Set namespace for installations and deployers

### DIFF
--- a/cmd/quickstart/install.go
+++ b/cmd/quickstart/install.go
@@ -287,14 +287,18 @@ func (o *installOptions) installLandscaper(ctx context.Context) error {
 	}
 	chartPath := path.Join(tempDir, fileInfos[0].Name())
 
-	landscaperValuesOverride := `
+	landscaperValuesOverride := fmt.Sprintf(`
 landscaper:
   landscaper:
     deployers:
     - container
     - helm
     - manifest
-`
+    deployerManagement:
+      namespace: %s
+      agent:
+        namespace: %s
+`, o.namespace, o.namespace)
 
 	if o.instRegistryIngress {
 		// when installing the ingress, we must add the registry credentials to the Landscaper values file


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request fixes issue #104 of the `quickstart install` command. The namespace specified in the command is now also used as namespace for the deployers and the installations which create them.

**Which issue(s) this PR fixes**:
Fixes #104 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Command "quickstart install" can be used with another namespace than "ls-system".
```
