### PR TITLE
Remove ns of landscaper installation in integration tests

### DIFF
--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -281,6 +281,7 @@ func runQuickstartUninstall(config *inttestutil.Config) error {
 		config.Kubeconfig,
 		"--namespace",
 		config.LandscaperNamespace,
+		"--delete-namespace",
 	}
 	uninstallCmd := quickstart.NewUninstallCommand(context.TODO())
 	uninstallCmd.SetArgs(uninstallArgs)


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the namespace of landscaper installation in integration tests

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
