### PR TITLE
Fix issue with parent directory calculation

### DIFF
--- a/cmd/components/add_helm_ls_deployitem.go
+++ b/cmd/components/add_helm_ls_deployitem.go
@@ -7,7 +7,6 @@ package components
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -108,15 +107,13 @@ func NewAddHelmLSDeployItemCommand(ctx context.Context) *cobra.Command {
 func (o *addHelmLsDeployItemOptions) Complete(args []string) error {
 	o.deployItemName = args[0]
 
-	o.chartDirectoryPath = filepath.Clean(o.chartDirectoryPath)
+	if o.chartDirectoryPath != "" {
+		o.chartDirectoryPath = filepath.Clean(o.chartDirectoryPath)
+	}
 
 	err := o.validate()
 	if err != nil {
 		return err
-	}
-
-	if o.chartDirectoryPath != "" {
-		o.chartDirectoryPath = filepath.Dir(o.chartDirectoryPath)
 	}
 
 	return nil
@@ -190,12 +187,6 @@ func (o *addHelmLsDeployItemOptions) validate() error {
 		}
 		if !fileInfo.IsDir() {
 			return fmt.Errorf("chart-directory is not a directory")
-		}
-
-		parentPath := filepath.Dir(o.chartDirectoryPath)
-		files, _ := ioutil.ReadDir(parentPath)
-		if len(files) > 1 {
-			return fmt.Errorf("the parent of the chart-directory does not contain only the chart-directory")
 		}
 	}
 
@@ -405,6 +396,7 @@ func (o *addHelmLsDeployItemOptions) createDirectoryResource() (*cdresources.Res
 			Type:             input.DirInputType,
 			Path:             o.chartDirectoryPath,
 			CompressWithGzip: &compress,
+			PreserveDir:      true,
 		},
 	}
 

--- a/cmd/components/add_helm_ls_deployitem.go
+++ b/cmd/components/add_helm_ls_deployitem.go
@@ -108,6 +108,8 @@ func NewAddHelmLSDeployItemCommand(ctx context.Context) *cobra.Command {
 func (o *addHelmLsDeployItemOptions) Complete(args []string) error {
 	o.deployItemName = args[0]
 
+	o.chartDirectoryPath = filepath.Clean(o.chartDirectoryPath)
+
 	err := o.validate()
 	if err != nil {
 		return err

--- a/cmd/components/create.go
+++ b/cmd/components/create.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/gardener/component-cli/ociclient/oci"
 	"github.com/gardener/landscaper/apis/mediatype"
 
 	"github.com/gardener/component-cli/pkg/commands/componentarchive/input"
@@ -28,8 +28,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
-
-var componentNameValidationRegexp = regexp.MustCompile("^[a-z0-9.\\-]+[.][a-z]{2,4}/[-a-z0-9/_.]*$") // nolint
 
 type createOptions struct {
 	// componentPath is the path to the directory containing the componentDescriptor.yaml
@@ -81,11 +79,12 @@ func (o *createOptions) Complete(args []string) error {
 }
 
 func (o *createOptions) validate() error {
-	if !componentNameValidationRegexp.Match([]byte(o.componentName)) {
-		return fmt.Errorf("the component name does not match pattern '^[a-z0-9.\\-]+[.][a-z]{2,4}/[-a-z0-9/_.]*$'")
+	_, err := oci.ParseRef("dummybasepath.com/" + o.componentName)
+	if err != nil {
+		return fmt.Errorf("the component name is invalid: %w. Valid component names are for example \"test.com/my/component\" or \"test.com/my-component\". For details see https://gardener.github.io/component-spec/format.html#component-names", err)
 	}
 
-	_, err := semver.NewVersion(o.componentVersion)
+	_, err = semver.NewVersion(o.componentVersion)
 	if err != nil {
 		return fmt.Errorf("component version %s is not semver compatible", o.componentVersion)
 	}

--- a/pkg/components/resource_writer.go
+++ b/pkg/components/resource_writer.go
@@ -48,6 +48,10 @@ func (w *ResourceWriter) Write(resourceOptions []cdresources.ResourceOptions) er
 				infoString += "  mediaType: " + resourceOptions[i].Input.MediaType + "\n"
 			}
 
+			if resourceOptions[i].Input.PreserveDir {
+				infoString += "  preserveDir: true\n"
+			}
+
 			infoString += "  compress: " + strconv.FormatBool(resourceOptions[i].Input.Compress()) + "\n"
 
 		} else if resourceOptions[i].Access != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes issue #113 .

**Which issue(s) this PR fixes**:
Fixes #113 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Fixes an issue with command `landscaper-cli component add helm-ls deployitem` if the provided chart-directory ends with a slash.
```
