### PR TITLE
Render blueprint documentation

### DIFF
--- a/docs/commands/blueprints/render.md
+++ b/docs/commands/blueprints/render.md
@@ -1,24 +1,66 @@
 # Render Blueprints
 
-> Source: [Landscaper CLI Usage](https://github.com/gardener/landscaper/blob/master/docs/usage/LandscaperCli.md)
+During the execution of a blueprint with an installation, Landscaper creates deploy items and subinstallations 
+based on the imported values.  The creation of these resources can be locally tested by using the Landscaper CLI and 
+its [render command](../../reference/landscaper-cli_blueprints_render.md).
 
-During the execution of a blueprint with an installation, deployitems and subinstallation are created by the landscaper based on the imported values.
+The simplest form of the command is:
 
-The generated resources can be locally tested by using the landsacper cli and its `render` command.
-
-```shell script
+```shell
 landscaper-cli blueprints render [path to blueprint directory]
 
-landscaper-cli blueprints render [path to blueprint directory] -f values.yaml -c component-descriptor.yaml
+# short form:
+landscaper-cli bp render [path to blueprint directory]
 ```
 
-A component descriptor can be defined by using the `-c` flag that is a path to the component descriptor.
+Note that you must specify the path to the blueprint **directory**, rather than the path to the `blueprint.yaml` 
+file in this directory.
 
-The command renders the resulting DeployItems(with the templating state) and the subinstallations and prints them to stdout.<br>
-The output will print the rendered resources in the following structure
+### Import Values
+
+Usually, a blueprint has import parameters that are used in the templating of deploy items and subinstallations.
+Values for the import parameters can be provided with the flag `-f` together with a path to a values yaml file. 
+The flag can be set multiple times to provide more than one values file.
+
+The render command does not only template the deploy items and subinstallations. It also validates the values against 
+the types of the corresponding import parameters in the blueprint.
+
+```shell
+landscaper-cli blueprints render [path to blueprint directory] -f [path to values yaml file]
+```
+
+The values yaml files must have the following structure:
+
+```yaml
+imports:
+  [parameter name 1]: [parameter value 1]
+  [parameter name 2]: [parameter value 2]
+  ...
+```
+
+The parameter names in the values yaml file must match with the import parameter names of the blueprint.
+
+
+### Examples 
+
+You can find a first simple example [here](../../examples/render-blueprint/01-render-with-values).
+It contains the following files:
+
+- [blueprint/blueprint.yaml](../../examples/render-blueprint/01-render-with-values/blueprint/blueprint.yaml)
+- [values.yaml](../../examples/render-blueprint/01-render-with-values/values.yaml)
+- [render.sh](../../examples/render-blueprint/01-render-with-values/render.sh) &mdash; you can run this script to try out the render command
+
+### More Examples
+
+There are further examples in the [Landscaper Examples](https://github.com/gardener/landscaper-examples/tree/master/render-blueprint) repository.
+
+### Output
+
+By default, the command prints the rendered resources to stdout. The output has the following structure:
+
 ```shell script
 --------------------------------------
--- state
+-- deployitems state
 --------------------------------------
 state:
   <execution name>: ...
@@ -30,6 +72,12 @@ apiVersion: landscaper.gardener.cloud/v1alpha1
 kind: DeployItem
 ...
 
+--------------------------------------
+-- subinstallations state
+--------------------------------------
+state:
+  ...
+  
 --------------------------------------
 -- subinstllations <subinstallation name>
 --------------------------------------
@@ -43,45 +91,69 @@ The resources are written as files in the following directory structure to the g
 ```
 /path/to/output
 ├── deployitems
-│   └── mydeployitem
-├── state
+│   ├── mydeployitem
+│   └── state
 └── subinstallations
-    └── mysubinstallation
+    ├── mysubinstallation
+    └── state
 ```
 
-#### Import Values
+### Using Data from the Component Descriptor
 
-The imported values can be defined using value files and reference them via commandline flag `-f`.
+The rendering of a blueprint might use data from the component descriptor. 
+With the flag `-c` or `--component-descriptor` a path to a local component descriptor file can be specified in the 
+render command. This allows to test the rendering before the component is uploaded into a component registry.
+
+The component descriptor might have references to further component descriptors. If they are needed for the rendering, 
+their paths can be specified with the flag `-a` or `--additional-component-descriptor`. This flag can be set multiple 
+times.
+
+##### Examples
+
+- [How to access the component descriptor](https://github.com/gardener/landscaper-examples/tree/master/render-blueprint/access-repository-context)
+- [How to access a referenced component descriptor](https://github.com/gardener/landscaper-examples/tree/master/render-blueprint/access-cd-reference)
+
+### Using Local Resources
+
+The rendering of a blueprint might use resources of the component. For example a JSON schema might be used for the 
+validation of import values. Again one wants to provide such resources as local files, so that the rendering can be 
+tested before the component is uploaded into a component registry. 
+
+With the flag `-r` or `--resources` one can specify the path to a so-called resources file. 
+An example of a resources file is shown below. It is a multi yaml file with a list of resources which will be added
+to the component descriptor. Beside other information, it contains the paths where local resources are located in
+the file system (field `input.path`). The render command can then access the local resources from there.
+
 ```yaml
-# /dev/values.yaml
-imports:
-  <import name>: <my value>
-```
-```shell script
-landscaper-cli blueprints render -f /dev/values.yaml [path to blueprint directory]
-```
+---
+type: blueprint
+name: blueprint
+version: v0.1.0
+relation: local
+input:
+  type: dir
+  path: ./blueprint
+  mediaType: application/vnd.gardener.landscaper.blueprint.v1+tar+gzip
+  compress: true
+...
+---
+type: landscaper.gardener.cloud/jsonschema
+name: vpa
+version: v0.1.0
+relation: local
+input:
+  type: file
+  path: ./resources/schemas/vpa.json
+  mediaType: application/vnd.gardener.landscaper.jsonschema.layer.v1.json
+  compress: false
+...
+``` 
 
-__Example__
-```
-apiVersion: landscaper.gardener.cloud/v1alpha1
-kind: Blueprint
-imports:
-- name: myFirstImport
-  schema:
-    type: string
-- name: mySecondImport
-  targetType: landscaper.gardener.cloud/kubernetes-cluster
-```
-```
-imports:
-  myFirstImport: "this is a import"
-  mySecondImport: 
-    metadata:
-      name: my-target
-      namespace: default
-    spec:
-       type: landscaper.gardener.cloud/kubernetes-cluster
-       config:
-         kubeconfig: |
-            apiVersion: ....
-```
+Remark: the resources file is primarily used by the 
+[command that creates a transport (CTF) file](../../reference/landscaper-cli_component-cli_component-archive.md),
+see also: [add a resource](https://github.com/gardener/component-cli/tree/main/docs#add-a-resource).
+
+##### Examples
+
+- [How to access a schema resource during the validation of import values](https://github.com/gardener/landscaper-examples/tree/master/render-blueprint/schema-in-cd)
+- [How to access a chart resource during the templating of a deploy item](https://github.com/gardener/landscaper-examples/tree/master/render-blueprint/resource-in-cd)

--- a/docs/examples/render-blueprint/01-render-with-values/blueprint/blueprint.yaml
+++ b/docs/examples/render-blueprint/01-render-with-values/blueprint/blueprint.yaml
@@ -1,0 +1,8 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+imports:
+  - name: myFirstImport
+    schema:
+      type: string
+  - name: mySecondImport
+    targetType: landscaper.gardener.cloud/kubernetes-cluster

--- a/docs/examples/render-blueprint/01-render-with-values/render.sh
+++ b/docs/examples/render-blueprint/01-render-with-values/render.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EXAMPLE_DIR="$(dirname $0)"
+BLUEPRINT_DIR=${EXAMPLE_DIR}/blueprint
+
+landscaper-cli blueprints render ${BLUEPRINT_DIR} -f ${EXAMPLE_DIR}/values.yaml

--- a/docs/examples/render-blueprint/01-render-with-values/values.yaml
+++ b/docs/examples/render-blueprint/01-render-with-values/values.yaml
@@ -1,0 +1,11 @@
+imports:
+  myFirstImport: "this is a import"
+  mySecondImport:
+    metadata:
+      name: my-target
+      namespace: default
+    spec:
+      type: landscaper.gardener.cloud/kubernetes-cluster
+      config:
+        kubeconfig: |
+          apiVersion: ...


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the documentation of the render blueprint command.
It adds links to the examples in the [landscaper-examples](https://github.com/gardener/landscaper-examples/tree/master/render-blueprint) repository. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
- Documentation of the render blueprint command
```
