### PR TITLE
automatic landscaper version determination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ COMPONENT_VERSION                              := $(shell grep github.com/garden
 
 GO_MOD_FILE := "go.mod"
 export COMPONENT_CLI_REF := $(shell grep component-cli $(REPO_ROOT)/$(GO_MOD_FILE))
+export LANDSCAPER_REF := $(shell grep "landscaper " $(REPO_ROOT)/$(GO_MOD_FILE))
 
 .PHONY: install-requirements
 install-requirements:

--- a/hack/cross-build.sh
+++ b/hack/cross-build.sh
@@ -10,6 +10,7 @@ CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
 COMPONENT_CLI_VERSION=$(echo $COMPONENT_CLI_REF | awk '{print $2}')
+LANDSCAPER_VERSION=$(echo $LANDSCAPER_REF | awk '{print $2}')
 
 if [[ $EFFECTIVE_VERSION == "" ]]; then
   EFFECTIVE_VERSION=$(cat $PROJECT_ROOT/VERSION)
@@ -30,6 +31,8 @@ for i in "${build_matrix[@]}"; do
   -ldflags "-s -w \
             -X github.com/gardener/landscapercli/pkg/version.LandscaperCliVersion=$EFFECTIVE_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.ComponentCliVersion=$COMPONENT_CLI_VERSION \
+            -X github.com/gardener/landscapercli/pkg/version.LandscaperGitVersion=$LANDSCAPER_VERSION \
+            -X github.com/gardener/landscapercli/pkg/version.LandscaperChartVersion=$LANDSCAPER_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty) \
             -X github.com/gardener/landscapercli/pkg/version.gitCommit=$(git rev-parse --verify HEAD)" \
   ${PROJECT_ROOT}/landscaper-cli

--- a/hack/install-cli.sh
+++ b/hack/install-cli.sh
@@ -10,11 +10,15 @@ CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
 COMPONENT_CLI_VERSION=$(echo $COMPONENT_CLI_REF | awk '{print $2}')
+LANDSCAPER_VERSION=$(echo $LANDSCAPER_REF | awk '{print $2}')
 GITTREESTATE=`([ -z "$(git status --porcelain 2>/dev/null)" ] && echo clean || echo dirty)`
+
 
 go install \
   -ldflags "-X github.com/gardener/landscapercli/pkg/version.LandscaperCliVersion=$EFFECTIVE_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.ComponentCliVersion=$COMPONENT_CLI_VERSION \
+            -X github.com/gardener/landscapercli/pkg/version.LandscaperGitVersion=$LANDSCAPER_VERSION \
+            -X github.com/gardener/landscapercli/pkg/version.LandscaperChartVersion=$LANDSCAPER_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.gitTreeState=$GITTREESTATE \
             -X github.com/gardener/landscapercli/pkg/version.gitCommit=$(git rev-parse --verify HEAD)" \
   ${PROJECT_ROOT}/landscaper-cli


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatic determination of correct landscaper version during build. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Automatic determination of correct landscaper version during build.
```
