### PR TITLE
update golang version to v1.17

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,9 +22,9 @@ landscaper-cli:
       component_descriptor: ~
     steps:
       verify:
-        image: 'golang:1.16.6'
+        image: 'golang:1.17'
       build:
-        image: 'golang:1.16.6'
+        image: 'golang:1.17'
         execute: 'build'
         output_dir: 'out'
         timeout: '5m'
@@ -36,7 +36,7 @@ landscaper-cli:
     pull-request:
       steps:
         run_integration_test:
-          image: 'golang:1.16.7-alpine3.14'
+          image: 'golang:1.17-alpine3.14'
           execute:
           - "dev_integration_test"
           - "--target-clustername=int-test-pr"
@@ -56,7 +56,7 @@ landscaper-cli:
           suppress_parallel_execution: true
       steps:
         run_integration_test:
-          image: 'golang:1.16.7-alpine3.14'
+          image: 'golang:1.17-alpine3.14'
           execute:
           - "dev_integration_test"
           - "--target-clustername=int-test-cron"
@@ -64,7 +64,7 @@ landscaper-cli:
     release:
       steps:
         run_integration_test:
-          image: 'golang:1.16.7-alpine3.14'
+          image: 'golang:1.17-alpine3.14'
           execute:
           - "dev_integration_test"
           - "--target-clustername=int-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the pipeline images used to golang version 1.17.x

**Which issue(s) this PR fixes**:

This should fix the issues in the pipeline steps when downloading `golang.org/x/tools/cmd/goimports`.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
