### PR TITLE
use new golangci-lint installation script

### DIFF
--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -9,6 +9,6 @@ set -e
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
-curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.32.2
+curl -sfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b $(go env GOPATH)/bin v1.32.2
 
 GO111MODULE=off go get golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous location of the golangci-lint script was marked as deprecated and is now no longer available.
Update with new and recommended script.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
