### PR TITLE
integration test cleanup

### DIFF
--- a/integration-test/tests/test_component_create.go
+++ b/integration-test/tests/test_component_create.go
@@ -164,7 +164,7 @@ func (t *componentCreateTest) addHelmDeployItemWithExternalChart(ctx context.Con
 		"--component-directory",
 		t.componentDir,
 		"--oci-reference",
-		"eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0",
+		"eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.17",
 		"--resource-version",
 		"v0.2.0",
 		"--cluster-param",


### PR DESCRIPTION
**What this PR does / why we need it**:

During some runs of the integration test, there are some resources with finalizers left in the test namespaces.
These resources prevent the namespaces to be deleted.

**Which issue(s) this PR fixes**:

This PR introduces a change that attempts to clean-up all remaining landscaper resources in the test namespaces before running the test cases.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
