### PR TITLE
Fix installation inspect does not show all installations 

### DIFF
--- a/cmd/installations/inspect/collector.go
+++ b/cmd/installations/inspect/collector.go
@@ -37,7 +37,15 @@ func (c *Collector) CollectInstallationsInCluster(name string, namespace string)
 		}
 	}
 	for _, inst := range instList.Items {
-		if inst.OwnerReferences == nil { //filters for root installations (since subInstallations have a owner reference)
+		//an installation is a root installation if it does NOT have any other installations as owner reference.
+		//It may have other custom resources as owners reference.
+		isRootInstallation := true
+		for _, ownerReference := range inst.OwnerReferences {
+			if ownerReference.Kind == lsv1alpha1.InstallationDefinition.Names.Kind {
+				isRootInstallation = false
+			}
+		}
+		if isRootInstallation {
 			filledInst, err := c.collectInstallationTree(inst.Name, inst.Namespace)
 			if err != nil {
 				return nil, fmt.Errorf("cannot get installation details for %s: %w", inst.Name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Installation Inspect command without specifying an installation name will list all installations. To detect the root installations, it previously checked the installation.ownerReference field to be nil. This fails, if the installation was created by any controller and has an owner reference to any custom resource.

Updated logic: detect a root installation if the ownerReference list contains NO entry refering to an installation. 

**Which issue(s) this PR fixes**:
installation inspect command does not show correctly show all root installations if they have been created by another controller.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
installation inspect now correctly shows all root installations even when they have been created by another controller
```
