### PR TITLE
Update ingress-nginx version v0.1.0 -> 4.0.18

### DIFF
--- a/docs/commands/create_component/create.md
+++ b/docs/commands/create_component/create.md
@@ -113,7 +113,7 @@ Example:
 ```
 landscaper-cli component add helm-ls deployitem nginx \
   --component-directory $LS_COMPONENT_DIR/demo-component \
-  --oci-reference eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0 \
+  --oci-reference eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18 \
   --resource-version v0.2.0 \
   --cluster-param target-cluster \
   --target-ns-param nginx-namespace

--- a/docs/commands/create_component/resources/02-step-add-helm-chart-in-oci/demo-component/resources.yaml
+++ b/docs/commands/create_component/resources/02-step-add-helm-chart-in-oci/demo-component/resources.yaml
@@ -16,5 +16,5 @@ version: v0.2.0
 relation: external
 access: 
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18
 ...

--- a/docs/commands/create_component/resources/03-step-add-local-helm-chart/demo-component/resources.yaml
+++ b/docs/commands/create_component/resources/03-step-add-local-helm-chart/demo-component/resources.yaml
@@ -16,7 +16,7 @@ version: v0.2.0
 relation: external
 access: 
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18
 ...
 ---
 type: helm

--- a/docs/commands/create_component/resources/04-step-add-secret-manifests/demo-component/resources.yaml
+++ b/docs/commands/create_component/resources/04-step-add-secret-manifests/demo-component/resources.yaml
@@ -16,7 +16,7 @@ version: v0.2.0
 relation: external
 access: 
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18
 ...
 ---
 type: helm

--- a/docs/commands/create_component/resources/05-step-prepare-push/demo-component/component-descriptor.yaml
+++ b/docs/commands/create_component/resources/05-step-prepare-push/demo-component/component-descriptor.yaml
@@ -15,7 +15,7 @@ component:
     type: blueprint
     version: v0.1.0
   - access:
-      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+      imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18
       type: ociRegistry
     name: nginx-chart
     relation: external

--- a/docs/commands/create_component/resources/05-step-prepare-push/demo-component/resources.yaml
+++ b/docs/commands/create_component/resources/05-step-prepare-push/demo-component/resources.yaml
@@ -16,7 +16,7 @@ version: v0.2.0
 relation: external
 access: 
   type: ociRegistry
-  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:v0.1.0
+  imageReference: eu.gcr.io/gardener-project/landscaper/tutorials/charts/ingress-nginx:4.0.18
 ...
 ---
 type: helm


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve documentation by updating the ingress-nginx version of the create_component tutorial. With the previous version, the following error occurred when trying to deploy the nginx controller:
`Failed to watch *v1beta1.Ingress: failed to list *v1beta1.Ingress: the server could not find the requested resource`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```doc developer
NONE
```
