### PR TITLE
Upgrade golang images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,9 +22,9 @@ landscaper-cli:
       component_descriptor: ~
     steps:
       verify:
-        image: 'golang:1.17'
+        image: 'golang:1.19'
       build:
-        image: 'golang:1.17'
+        image: 'golang:1.19'
         execute: 'build'
         output_dir: 'out'
         timeout: '5m'
@@ -36,7 +36,7 @@ landscaper-cli:
     pull-request:
       steps:
         run_integration_test:
-          image: 'golang:1.17-alpine3.16'
+          image: 'golang:1.19-alpine3.16'
           execute:
           - "dev_integration_test"
           - "--target-clustername=int-test-pr"
@@ -56,7 +56,7 @@ landscaper-cli:
           suppress_parallel_execution: true
       steps:
         run_integration_test:
-          image: 'golang:1.18-alpine3.16'
+          image: 'golang:1.19-alpine3.16'
           execute:
           - "dev_integration_test"
           - "--target-clustername=int-test-cron"
@@ -64,7 +64,7 @@ landscaper-cli:
     release:
       steps:
         run_integration_test:
-          image: 'golang:1.18-alpine3.16'
+          image: 'golang:1.19-alpine3.16'
           execute:
           - "dev_integration_test"
           - "--target-clustername=int-test"

--- a/cmd/blueprints/push.go
+++ b/cmd/blueprints/push.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -116,7 +115,7 @@ func (o *pushOptions) Complete(args []string) error {
 
 // Validate validates push options
 func (o *pushOptions) Validate() error {
-	data, err := ioutil.ReadFile(filepath.Join(o.blueprintPath, lsv1alpha1.BlueprintFileName))
+	data, err := os.ReadFile(filepath.Join(o.blueprintPath, lsv1alpha1.BlueprintFileName))
 	if err != nil {
 		return err
 	}

--- a/cmd/blueprints/validate.go
+++ b/cmd/blueprints/validate.go
@@ -7,7 +7,6 @@ package blueprints
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -54,7 +53,7 @@ func NewValidationCommand(_ context.Context) *cobra.Command {
 }
 
 func (o *validationOptions) run() error {
-	data, err := ioutil.ReadFile(filepath.Join(o.blueprintPath, lsv1alpha1.BlueprintFileName))
+	data, err := os.ReadFile(filepath.Join(o.blueprintPath, lsv1alpha1.BlueprintFileName))
 	if err != nil {
 		return err
 	}

--- a/cmd/components/add_manifest_deployitem.go
+++ b/cmd/components/add_manifest_deployitem.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -366,7 +365,7 @@ func (o *addManifestDeployItemOptions) readManifests() ([]managedresource.Manife
 }
 
 func (o *addManifestDeployItemOptions) readManifest(filename string) (*managedresource.Manifest, error) {
-	yamlData, err := ioutil.ReadFile(filename)
+	yamlData, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/installations/inspect/collector.go
+++ b/cmd/installations/inspect/collector.go
@@ -9,13 +9,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//Collector is responsible for collecting CR (installations, executions, deployItems) from a cluster using the K8sClient.
+// Collector is responsible for collecting CR (installations, executions, deployItems) from a cluster using the K8sClient.
 type Collector struct {
 	K8sClient client.Client
 }
 
-//CollectInstallationsInCluster collects a single installation (including all referenced executions and deployitems)
-//or all installations if name is empty.
+// CollectInstallationsInCluster collects a single installation (including all referenced executions and deployitems)
+// or all installations if name is empty.
 func (c *Collector) CollectInstallationsInCluster(name string, namespace string) ([]*InstallationTree, error) {
 	if name != "" {
 		installation, err := c.collectInstallationTree(name, namespace)

--- a/cmd/installations/inspect/printer.go
+++ b/cmd/installations/inspect/printer.go
@@ -14,7 +14,7 @@ const (
 
 const terminalWidth = 120
 
-//PrintableTreeNode contains the structure for a printable tree.
+// PrintableTreeNode contains the structure for a printable tree.
 type PrintableTreeNode struct {
 	Headline    string
 	WideData    string // will be displayed in '-o wide' mode
@@ -56,7 +56,7 @@ func (node *PrintableTreeNode) print(output *strings.Builder, preFix string, isL
 	}
 }
 
-//PrintTrees turns the given PrintableTreeNodes into a formated tree as strings.Builder.
+// PrintTrees turns the given PrintableTreeNodes into a formated tree as strings.Builder.
 func PrintTrees(nodes []PrintableTreeNode) strings.Builder {
 	output := strings.Builder{}
 	for _, node := range nodes {

--- a/cmd/installations/inspect/transformer.go
+++ b/cmd/installations/inspect/transformer.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-//Transformer can transform from []*InstallationTree to printable []PrintableTreeNodes with different transformation options.
+// Transformer can transform from []*InstallationTree to printable []PrintableTreeNodes with different transformation options.
 type Transformer struct {
 	DetailedMode   bool
 	ShowExecutions bool
@@ -20,7 +20,7 @@ type Transformer struct {
 	WideMode       bool
 }
 
-//TransformToPrintableTrees transform a []*InstallationTree to []PrintableTreeNodes for the Printer.
+// TransformToPrintableTrees transform a []*InstallationTree to []PrintableTreeNodes for the Printer.
 func (t Transformer) TransformToPrintableTrees(installationTrees []*InstallationTree) ([]PrintableTreeNode, error) {
 	var printableTrees []PrintableTreeNode
 

--- a/cmd/installations/inspect/tree.go
+++ b/cmd/installations/inspect/tree.go
@@ -5,7 +5,7 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 )
 
-//InstallationTree contains the Installation and the references to Sub-Installations and the Execution.
+// InstallationTree contains the Installation and the references to Sub-Installations and the Execution.
 type InstallationTree struct {
 	SubInstallations []*InstallationTree      `json:"subInstallations,omitempty"`
 	Execution        *ExecutionTree           `json:"execution,omitempty"`
@@ -32,7 +32,7 @@ func (i *InstallationTree) filterForFailedInstallation() *InstallationTree {
 
 }
 
-//ExecutionTree contains the Execution and the references to all DeployItems.
+// ExecutionTree contains the Execution and the references to all DeployItems.
 type ExecutionTree struct {
 	DeployItems []*DeployItemLeaf     `json:"deployItems,omitempty"`
 	Execution   *lsv1alpha1.Execution `json:"execution,omitempty"`
@@ -54,7 +54,7 @@ func (e *ExecutionTree) filterForFailedExecution() *ExecutionTree {
 	return nil
 }
 
-//DeployItemLeaf contains a DeployItem.
+// DeployItemLeaf contains a DeployItem.
 type DeployItemLeaf struct {
 	DeployItem *lsv1alpha1.DeployItem `json:"deployItem,omitempty"`
 }

--- a/cmd/installations/set_import_parameters.go
+++ b/cmd/installations/set_import_parameters.go
@@ -29,7 +29,7 @@ type importParametersOptions struct {
 	outputPath string
 }
 
-//NewSetImportParametersCommand sets input parameters from an installation to hardcoded values (as importDataMappings)
+// NewSetImportParametersCommand sets input parameters from an installation to hardcoded values (as importDataMappings)
 func NewSetImportParametersCommand(ctx context.Context) *cobra.Command {
 	opts := &importParametersOptions{}
 	cmd := &cobra.Command{

--- a/cmd/installations/set_import_parameters.go
+++ b/cmd/installations/set_import_parameters.go
@@ -3,7 +3,6 @@ package installations
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -155,7 +154,7 @@ func createJSONRawMessageValueWithStringOrNumericType(parameter string) lsv1alph
 }
 
 func readInstallationFromFile(o *importParametersOptions, installation *lsv1alpha1.Installation) error {
-	installationFileData, err := ioutil.ReadFile(o.installationPath)
+	installationFileData, err := os.ReadFile(o.installationPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/quickstart/install.go
+++ b/cmd/quickstart/install.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -117,7 +116,7 @@ prerequisites (!):
 }
 
 func (o *installOptions) ReadLandscaperValues() error {
-	content, err := ioutil.ReadFile(o.landscaperValuesPath)
+	content, err := os.ReadFile(o.landscaperValuesPath)
 	if err != nil {
 		return fmt.Errorf("cannot read file: %w", err)
 	}
@@ -261,7 +260,7 @@ func (o *installOptions) Complete(args []string) error {
 func (o *installOptions) installLandscaper(ctx context.Context) error {
 	fmt.Println("Installing Landscaper")
 
-	tempDir, err := ioutil.TempDir(".", "landscaper-chart-tmp-*")
+	tempDir, err := os.MkdirTemp(".", "landscaper-chart-tmp-*")
 	if err != nil {
 		return err
 	}
@@ -277,7 +276,7 @@ func (o *installOptions) installLandscaper(ctx context.Context) error {
 		return err
 	}
 
-	fileInfos, err := ioutil.ReadDir(tempDir)
+	fileInfos, err := os.ReadDir(tempDir)
 	if err != nil {
 		return err
 	}
@@ -329,7 +328,7 @@ landscaper:
 `, landscaperValuesOverride, string(marshaledRegistryAuths))
 	}
 
-	tmpFile, err := ioutil.TempFile(".", "landscaper-values-override-")
+	tmpFile, err := os.CreateTemp(".", "landscaper-values-override-")
 	if err != nil {
 		return fmt.Errorf("cannot create temporary file: %w", err)
 	}
@@ -339,7 +338,7 @@ landscaper:
 		}
 	}()
 
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(landscaperValuesOverride), os.ModePerm); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(landscaperValuesOverride), os.ModePerm); err != nil {
 		return fmt.Errorf("cannot write to file: %w", err)
 	}
 

--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"text/template"
@@ -245,7 +244,7 @@ func startOCIRegistryPortForward(k8sClient client.Client, namespace, kubeconfigP
 }
 
 func uploadEchoServerHelmChart(landscaperNamespace string) (string, error) {
-	tempDir1, err := ioutil.TempDir(".", "landscaper-chart-tmp1-*")
+	tempDir1, err := os.MkdirTemp(".", "landscaper-chart-tmp1-*")
 	if err != nil {
 		return "", err
 	}
@@ -264,7 +263,7 @@ func uploadEchoServerHelmChart(landscaperNamespace string) (string, error) {
 		}
 	}()
 
-	tempDir2, err := ioutil.TempDir(".", "landscaper-chart-tmp2-*")
+	tempDir2, err := os.MkdirTemp(".", "landscaper-chart-tmp2-*")
 	if err != nil {
 		return "", err
 	}
@@ -311,7 +310,7 @@ func runQuickstartInstall(config *inttestutil.Config) error {
 		return fmt.Errorf("cannot template landscaper values: %w", err)
 	}
 
-	tmpFile, err := ioutil.TempFile(".", "landscaper-values-")
+	tmpFile, err := os.CreateTemp(".", "landscaper-values-")
 	if err != nil {
 		return fmt.Errorf("cannot create temporary file: %w", err)
 	}
@@ -321,7 +320,7 @@ func runQuickstartInstall(config *inttestutil.Config) error {
 		}
 	}()
 
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(landscaperValues), os.ModePerm); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(landscaperValues), os.ModePerm); err != nil {
 		return fmt.Errorf("cannot write to file: %w", err)
 	}
 

--- a/integration-test/tests/test_component_create.go
+++ b/integration-test/tests/test_component_create.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -314,7 +313,7 @@ func (t *componentCreateTest) setBaseURL(ctx context.Context) error {
 
 	componentDescriptorPath := filepath.Join(t.componentDir, "component-descriptor.yaml")
 
-	data, err := ioutil.ReadFile(componentDescriptorPath)
+	data, err := os.ReadFile(componentDescriptorPath)
 	if err != nil {
 		return fmt.Errorf("could not read component descriptor: %w", err)
 	}
@@ -323,7 +322,7 @@ func (t *componentCreateTest) setBaseURL(ctx context.Context) error {
 	baseURLElement := fmt.Sprintf(`baseUrl: "%s"`, t.config.RegistryBaseURL)
 	newCdString := strings.Replace(oldCdString, `baseUrl: ""`, baseURLElement, 1)
 
-	err = ioutil.WriteFile(componentDescriptorPath, []byte(newCdString), 0755)
+	err = os.WriteFile(componentDescriptorPath, []byte(newCdString), 0755)
 	if err != nil {
 		return fmt.Errorf("could not write component descriptor: %w", err)
 	}
@@ -423,12 +422,12 @@ func (t *componentCreateTest) createInstallation(ctx context.Context) error {
 				},
 			},
 			ImportDataMappings: map[string]lsv1alpha1.AnyJSON{
-				"nginx-namespace": lsv1alpha1.AnyJSON{RawMessage: []byte(`"` + t.config.TestNamespace + `"`)},
-				"password-1":      lsv1alpha1.AnyJSON{RawMessage: []byte(`"pw1"`)},
-				"password-2":      lsv1alpha1.AnyJSON{RawMessage: []byte(`"pw2"`)},
-				"word":            lsv1alpha1.AnyJSON{RawMessage: []byte(`"test"`)},
-				"sleepTimeBefore": lsv1alpha1.AnyJSON{RawMessage: []byte(`0`)},
-				"sleepTimeAfter":  lsv1alpha1.AnyJSON{RawMessage: []byte(`0`)},
+				"nginx-namespace": {RawMessage: []byte(`"` + t.config.TestNamespace + `"`)},
+				"password-1":      {RawMessage: []byte(`"pw1"`)},
+				"password-2":      {RawMessage: []byte(`"pw2"`)},
+				"word":            {RawMessage: []byte(`"test"`)},
+				"sleepTimeBefore": {RawMessage: []byte(`0`)},
+				"sleepTimeAfter":  {RawMessage: []byte(`0`)},
 			},
 		},
 	}

--- a/integration-test/tests/test_installations_create.go
+++ b/integration-test/tests/test_installations_create.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -122,7 +121,7 @@ func (t *installationsCreateTest) run() error {
 }
 
 func (t *installationsCreateTest) writeInstallationToFile(cmdOutput *bytes.Buffer) error {
-	installationDir, err := ioutil.TempDir(".", "dummy-installation-*")
+	installationDir, err := os.MkdirTemp(".", "dummy-installation-*")
 	if err != nil {
 		return fmt.Errorf("cannot create temp directory: %w", err)
 	}
@@ -136,7 +135,7 @@ func (t *installationsCreateTest) writeInstallationToFile(cmdOutput *bytes.Buffe
 	// However, we must set the URL to the first one for the installation to work
 	installationStr := strings.Replace(cmdOutput.String(), "localhost:5000", t.config.RegistryBaseURL, -1)
 
-	err = ioutil.WriteFile(path.Join(t.installationDir, "installation-generated.yaml"), []byte(installationStr), os.ModePerm)
+	err = os.WriteFile(path.Join(t.installationDir, "installation-generated.yaml"), []byte(installationStr), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write to file: %w", err)
 	}
@@ -224,7 +223,7 @@ func (t *installationsCreateTest) applyToCluster() error {
 	ctx := context.TODO()
 
 	fmt.Printf("Preparing installation")
-	installationFileData, err := ioutil.ReadFile(path.Join(t.installationDir, "installation-set-import-params.yaml"))
+	installationFileData, err := os.ReadFile(path.Join(t.installationDir, "installation-set-import-params.yaml"))
 	if err != nil {
 		return fmt.Errorf("cannot read temp installation file: %w", err)
 	}
@@ -385,7 +384,7 @@ func (t *installationsCreateTest) createAndUploadComponent() error {
 
 	ctx := context.TODO()
 
-	cdDir, err := ioutil.TempDir(".", "dummy-cd-*")
+	cdDir, err := os.MkdirTemp(".", "dummy-cd-*")
 	if err != nil {
 		return fmt.Errorf("cannot create component descriptor directory: %w", err)
 	}
@@ -402,7 +401,7 @@ func (t *installationsCreateTest) createAndUploadComponent() error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal component descriptor: %w", err)
 	}
-	err = ioutil.WriteFile(path.Join(cdDir, "component-descriptor.yaml"), marshaledCd, os.ModePerm)
+	err = os.WriteFile(path.Join(cdDir, "component-descriptor.yaml"), marshaledCd, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write component descriptor file: %w", err)
 	}
@@ -415,7 +414,7 @@ func (t *installationsCreateTest) createAndUploadComponent() error {
 
 	marshaledBp := t.createBlueprint()
 
-	err = ioutil.WriteFile(path.Join(bpDir, "blueprint.yaml"), []byte(marshaledBp), os.ModePerm)
+	err = os.WriteFile(path.Join(bpDir, "blueprint.yaml"), []byte(marshaledBp), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write blueprint.yaml: %w", err)
 	}
@@ -442,7 +441,7 @@ access:
 `, t.blueprintName, t.componentVersion, t.config.RegistryBaseURL)
 
 	resourceFile := path.Join(cdDir, "resources.yaml")
-	err = ioutil.WriteFile(resourceFile, []byte(resourcesYaml), os.ModePerm)
+	err = os.WriteFile(resourceFile, []byte(resourcesYaml), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("cannot write component descriptor resources file: %w", err)
 	}

--- a/pkg/blueprints/blueprint_builder.go
+++ b/pkg/blueprints/blueprint_builder.go
@@ -114,11 +114,11 @@ func (b *BlueprintBuilder) AddDeployExecution(deployItemName string) {
 
 // AddExportExecution adds one export executions for all export parameters of one deployitem:
 // exportExecutions:
-// - name: [name of the export execution, here equal to the deployitem name]
-//   type: GoTemplate
-//   template: |
+//   - name: [name of the export execution, here equal to the deployitem name]
+//     type: GoTemplate
+//     template: |
 //     exports:
-//       [parameter name]: {{ index .values "deployitems" "[deployitem name]" "[internal parameter name]" }}
+//     [parameter name]: {{ index .values "deployitems" "[deployitem name]" "[internal parameter name]" }}
 func (b *BlueprintBuilder) AddExportExecution(deployItemName string, exportDefinitions map[string]*v1alpha1.ExportDefinition) {
 	if len(exportDefinitions) == 0 {
 		return

--- a/pkg/blueprints/blueprint_reader.go
+++ b/pkg/blueprints/blueprint_reader.go
@@ -1,7 +1,7 @@
 package blueprints
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -22,7 +22,7 @@ func NewBlueprintReader(blueprintPath string) *BlueprintReader {
 
 func (r *BlueprintReader) Read() (*v1alpha1.Blueprint, error) {
 	blueprintFilePath := filepath.Join(r.blueprintPath, v1alpha1.BlueprintFileName)
-	data, err := ioutil.ReadFile(blueprintFilePath)
+	data, err := os.ReadFile(blueprintFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/components/component_descriptor_reader.go
+++ b/pkg/components/component_descriptor_reader.go
@@ -1,7 +1,7 @@
 package components
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/gardener/landscapercli/pkg/util"
 
@@ -22,7 +22,7 @@ func NewComponentDescriptorReader(componentPath string) *ComponentDescriptorRead
 
 func (r *ComponentDescriptorReader) Read() (*cd.ComponentDescriptor, error) {
 	componentDescriptorFilePath := util.ComponentDescriptorFilePath(r.componentPath)
-	data, err := ioutil.ReadFile(componentDescriptorFilePath)
+	data, err := os.ReadFile(componentDescriptorFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/k8sclient.go
+++ b/pkg/util/k8sclient.go
@@ -12,7 +12,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
-//GetK8sClientFromCurrentConfiguredCluster returns a k8sClient and a namespace from the current context of the kubectl program.
+// GetK8sClientFromCurrentConfiguredCluster returns a k8sClient and a namespace from the current context of the kubectl program.
 func GetK8sClientFromCurrentConfiguredCluster() (client.Client, string, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
@@ -214,7 +214,7 @@ func gracefullyDeleteNamespace(k8sClient client.Client, namespace string, sleepT
 }
 
 func BuildKubernetesClusterTarget(name, namespace, kubeconfigPath string) (*lsv1alpha1.Target, error) {
-	kubeconfigContent, err := ioutil.ReadFile(kubeconfigPath)
+	kubeconfigContent, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read kubeconfig: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
I'd like to upgrade golang, but since the tests run in the pipeline are based on the pipeline definitions in the `master` branch, the PR won't get green if we don't upgrade the images used by the pipeline first.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
