### PR TITLE
Enable 'target create' subcommand to store content in secret

### DIFF
--- a/cmd/targets/create.go
+++ b/cmd/targets/create.go
@@ -9,13 +9,19 @@ import (
 )
 
 func NewCreateCommand(ctx context.Context) *cobra.Command {
+	opts := &types.TargetCreateOpts{}
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
 		Short:   "command for creating different types of targets",
 	}
+	opts.AddFlags(cmd.PersistentFlags())
+	err := cmd.MarkPersistentFlagRequired("name")
+	if err != nil {
+		panic(err)
+	}
 
-	cmd.AddCommand(types.NewKubernetesClusterCommand(ctx))
+	cmd.AddCommand(types.NewKubernetesClusterCommand(ctx, opts))
 
 	return cmd
 }

--- a/cmd/targets/types/generic.go
+++ b/cmd/targets/types/generic.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0package component
+
+package types
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+
+	"github.com/gardener/landscapercli/pkg/util"
+)
+
+// TypedTargetCreator is a function which takes a context and the common target creation options
+// and returns the content which should be put into the target, as well as the target's type.
+type TypedTargetCreator func(context.Context, *TargetCreateOpts) ([]byte, lsv1alpha1.TargetType, error)
+
+// TargetCreateOpts contains the options which all target creation subcommands have in common.
+type TargetCreateOpts struct {
+	// Name is the name of the target. It is required.
+	Name string
+	// Namespace is the namespace of the target.
+	Namespace string
+	// OutputPath defines where to write the generated target to.
+	// If it is empty, the generated target will be printed to stdout,
+	// otherwise it will be put into a file at the specified path.
+	OutputPath string
+	// SecretName defines the name of the secret which should be used to store the target's content.
+	// If empty, the content will be put into the target's spec directly.
+	SecretName string
+}
+
+func (o *TargetCreateOpts) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.Name, "name", "", "name of the target (required)")
+	fs.StringVarP(&o.Namespace, "namespace", "n", "", "namespace of the target")
+	fs.StringVarP(&o.OutputPath, "output-file", "o", "", "file path for the resulting target yaml, leave empty for stdout")
+	fs.StringVarP(&o.SecretName, "secret", "s", "", "name of the secret to store the target's content in (content will be stored in target spec directly, if empty)")
+}
+
+// NewTargetCreateSubcommand wraps target-type-specific code with generic functionality for target creation.
+// It overwrites the given command's Run field with a function that
+//   - uses the given TypedTargetCreator function to generate the target's content
+//   - generates the Target yaml and potentially secret yaml, depending on the options
+//   - either prints the yaml file(s) to stdout or the given path, depending on the options
+func NewTargetCreateSubcommand(ctx context.Context, cmd *cobra.Command, run TypedTargetCreator, opts *TargetCreateOpts) *cobra.Command {
+	handleError := func(err error) {
+		cmd.PrintErr(err)
+		os.Exit(1)
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		content, targetType, err := run(ctx, opts)
+		if err != nil {
+			cmd.PrintErr(err.Error())
+			os.Exit(1)
+		}
+
+		target, secret := util.BuildTargetWithContent(opts.Name, opts.Namespace, targetType, content, opts.SecretName)
+
+		res := strings.Builder{}
+
+		if secret != nil {
+			marshalledSecret, err := yaml.Marshal(secret)
+			if err != nil {
+				handleError(fmt.Errorf("cannot marshal secret yaml: %w", err))
+			}
+			res.WriteString(string(marshalledSecret))
+			if !strings.HasSuffix(res.String(), "\n") {
+				res.WriteString("\n")
+			}
+			res.WriteString("---\n")
+		}
+
+		marshalledTarget, err := yaml.Marshal(target)
+		if err != nil {
+			handleError(fmt.Errorf("cannot marshal target yaml: %w", err))
+		}
+		res.WriteString(string(marshalledTarget))
+
+		if opts.OutputPath == "" {
+			cmd.Println(res.String())
+		} else {
+			f, err := os.Create(opts.OutputPath)
+			if err != nil {
+				handleError(fmt.Errorf("error creating file %s: %w", opts.OutputPath, err))
+			}
+			_, err = f.WriteString(res.String())
+			if err != nil {
+				handleError(fmt.Errorf("error writing file %s: %w", opts.OutputPath, err))
+			}
+			cmd.Printf("Wrote target to %s", opts.OutputPath)
+		}
+	}
+
+	return cmd
+}

--- a/cmd/targets/types/kubernetes_cluster.go
+++ b/cmd/targets/types/kubernetes_cluster.go
@@ -2,31 +2,21 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strings"
 
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/apis/core/v1alpha1/targettypes"
-	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"sigs.k8s.io/yaml"
 
-	"github.com/gardener/landscapercli/pkg/logger"
 	"github.com/gardener/landscapercli/pkg/util"
 )
 
 type kubernetesClusterOpts struct {
-	name                 string
-	namespace            string
 	targetKubeconfigPath string
-	secretName           string
-
-	//outputPath is the path to write the installation.yaml to
-	outputPath string
 }
 
-func NewKubernetesClusterCommand(ctx context.Context) *cobra.Command {
+func NewKubernetesClusterCommand(ctx context.Context, superOpts *TargetCreateOpts) *cobra.Command {
 	opts := &kubernetesClusterOpts{}
 	cmd := &cobra.Command{
 		Use: "kubernetes-cluster --name [name] --namespace [namespace] " +
@@ -36,69 +26,24 @@ func NewKubernetesClusterCommand(ctx context.Context) *cobra.Command {
 		Example: "landscaper-cli targets create kubernetes-cluster --name my-target --namespace my-namespace " +
 			"--target-kubeconfig  kubeconfig.yaml",
 		Short: "create a target of type " + string(targettypes.KubernetesClusterTargetType),
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := opts.run(ctx, cmd, logger.Log); err != nil {
-				cmd.PrintErr(err.Error())
-				os.Exit(1)
-			}
-		},
 	}
 
 	cmd.SetOut(os.Stdout)
 
 	opts.AddFlags(cmd.Flags())
-	cmd.MarkFlagRequired("name")
-	cmd.MarkFlagRequired("target-kubeconfig")
+	err := cmd.MarkFlagRequired("target-kubeconfig")
+	if err != nil {
+		panic(err)
+	}
 
-	return cmd
+	return NewTargetCreateSubcommand(ctx, cmd, opts.run, superOpts)
 }
 
-func (o *kubernetesClusterOpts) run(ctx context.Context, cmd *cobra.Command, log logr.Logger) error {
-	target, secret, err := util.BuildKubernetesClusterTarget(o.name, o.namespace, o.targetKubeconfigPath, o.secretName)
-	if err != nil {
-		return fmt.Errorf("cannot build target object: %w", err)
-	}
-
-	res := strings.Builder{}
-
-	if secret != nil {
-		marshalledSecret, err := yaml.Marshal(secret)
-		if err != nil {
-			return fmt.Errorf("cannot marshal secret yaml: %w", err)
-		}
-		res.WriteString(string(marshalledSecret))
-		if !strings.HasSuffix(res.String(), "\n") {
-			res.WriteString("\n")
-		}
-		res.WriteString("---\n")
-	}
-
-	marshalledTarget, err := yaml.Marshal(target)
-	if err != nil {
-		return fmt.Errorf("cannot marshal target yaml: %w", err)
-	}
-	res.WriteString(string(marshalledTarget))
-
-	if o.outputPath == "" {
-		cmd.Println(res.String())
-	} else {
-		f, err := os.Create(o.outputPath)
-		if err != nil {
-			return fmt.Errorf("error creating file %s: %w", o.outputPath, err)
-		}
-		_, err = f.WriteString(res.String())
-		if err != nil {
-			return fmt.Errorf("error writing file %s: %w", o.outputPath, err)
-		}
-		cmd.Printf("Wrote target to %s", o.outputPath)
-	}
-	return nil
+func (o *kubernetesClusterOpts) run(ctx context.Context, opts *TargetCreateOpts) ([]byte, lsv1alpha1.TargetType, error) {
+	content, err := util.GetKubernetesClusterTargetContent(o.targetKubeconfigPath)
+	return content, targettypes.KubernetesClusterTargetType, err
 }
 
 func (o *kubernetesClusterOpts) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.name, "name", "", "name of the target")
-	fs.StringVar(&o.namespace, "namespace", "", "namespace of the target (optional)")
 	fs.StringVar(&o.targetKubeconfigPath, "target-kubeconfig", "", "path to the kubeconfig where the created target object will point to")
-	fs.StringVarP(&o.outputPath, "output-file", "o", "", "file path for the resulting target yaml")
-	fs.StringVarP(&o.secretName, "secret", "s", util.NoSecretIdentifier, fmt.Sprintf("if set to anything but '%s', the data will be stored in a secret with this name which is referenced in the target (in case of an empty string, the target's name will be used)", util.NoSecretIdentifier))
 }

--- a/cmd/targets/types/kubernetes_cluster.go
+++ b/cmd/targets/types/kubernetes_cluster.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -38,11 +37,6 @@ func NewKubernetesClusterCommand(ctx context.Context) *cobra.Command {
 			"--target-kubeconfig  kubeconfig.yaml",
 		Short: "create a target of type " + string(targettypes.KubernetesClusterTargetType),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := opts.Complete(args); err != nil {
-				cmd.PrintErr(err.Error())
-				os.Exit(1)
-			}
-
 			if err := opts.run(ctx, cmd, logger.Log); err != nil {
 				cmd.PrintErr(err.Error())
 				os.Exit(1)
@@ -53,20 +47,10 @@ func NewKubernetesClusterCommand(ctx context.Context) *cobra.Command {
 	cmd.SetOut(os.Stdout)
 
 	opts.AddFlags(cmd.Flags())
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("target-kubeconfig")
 
 	return cmd
-}
-
-func (o *kubernetesClusterOpts) Complete(args []string) error {
-	if o.name == "" {
-		return errors.New("--name must be defined")
-	}
-
-	if o.targetKubeconfigPath == "" {
-		return errors.New("--target-kubeconfig must be defined")
-	}
-
-	return nil
 }
 
 func (o *kubernetesClusterOpts) run(ctx context.Context, cmd *cobra.Command, log logr.Logger) error {

--- a/docs/reference/landscaper-cli_targets_create.md
+++ b/docs/reference/landscaper-cli_targets_create.md
@@ -5,7 +5,11 @@ command for creating different types of targets
 ### Options
 
 ```
-  -h, --help   help for create
+  -h, --help                 help for create
+      --name string          name of the target (required)
+  -n, --namespace string     namespace of the target
+  -o, --output-file string   file path for the resulting target yaml, leave empty for stdout
+  -s, --secret string        name of the secret to store the target's content in (content will be stored in target spec directly, if empty)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/landscaper-cli_targets_create_kubernetes-cluster.md
+++ b/docs/reference/landscaper-cli_targets_create_kubernetes-cluster.md
@@ -16,9 +16,6 @@ landscaper-cli targets create kubernetes-cluster --name my-target --namespace my
 
 ```
   -h, --help                       help for kubernetes-cluster
-      --name string                name of the target
-      --namespace string           namespace of the target (optional)
-  -o, --output-file string         file path for the resulting target yaml
       --target-kubeconfig string   path to the kubeconfig where the created target object will point to
 ```
 
@@ -30,6 +27,10 @@ landscaper-cli targets create kubernetes-cluster --name my-target --namespace my
       --disable-caller       disable the caller of logs (default true)
       --disable-stacktrace   disable the stacktrace of error logs (default true)
       --disable-timestamp    disable timestamp output (default true)
+      --name string          name of the target (required)
+  -n, --namespace string     namespace of the target
+  -o, --output-file string   file path for the resulting target yaml, leave empty for stdout
+  -s, --secret string        name of the secret to store the target's content in (content will be stored in target spec directly, if empty)
   -v, --verbosity int        number for the log level verbosity (default 1)
 ```
 

--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -168,7 +168,7 @@ func run() error {
 		return fmt.Errorf("upload of echo-server helm chart failed: %w", err)
 	}
 
-	target, _, err := util.BuildKubernetesClusterTarget("test-target", "", config.Kubeconfig, util.NoSecretIdentifier)
+	target, _, err := util.BuildKubernetesClusterTarget("test-target", "", config.Kubeconfig, "")
 	if err != nil {
 		return fmt.Errorf("cannot build target: %w", err)
 	}

--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -168,7 +168,7 @@ func run() error {
 		return fmt.Errorf("upload of echo-server helm chart failed: %w", err)
 	}
 
-	target, err := util.BuildKubernetesClusterTarget("test-target", "", config.Kubeconfig)
+	target, _, err := util.BuildKubernetesClusterTarget("test-target", "", config.Kubeconfig, util.NoSecretIdentifier)
 	if err != nil {
 		return fmt.Errorf("cannot build target: %w", err)
 	}

--- a/integration-test/tests/test_installations_create.go
+++ b/integration-test/tests/test_installations_create.go
@@ -193,12 +193,13 @@ func (t *installationsCreateTest) createTarget() error {
 	ctx := context.TODO()
 
 	fmt.Println("Executing landscaper-cli targets create kubernetes-cluster")
-	cmdTargetCreate := types.NewKubernetesClusterCommand(ctx)
+	cmdTargetCreate := types.NewKubernetesClusterCommand(ctx, &types.TargetCreateOpts{
+		Name:      t.targetName,
+		Namespace: t.config.TestNamespace,
+	})
 	outBufTargetCreate := &bytes.Buffer{}
 	cmdTargetCreate.SetOut(outBufTargetCreate)
 	argsTargetCreateParams := []string{
-		"--name=" + t.targetName,
-		"--namespace=" + t.config.TestNamespace,
 		"--target-kubeconfig=" + t.config.Kubeconfig,
 	}
 	cmdTargetCreate.SetArgs(argsTargetCreateParams)


### PR DESCRIPTION
**What this PR does / why we need it**:
It is now possible to have the `landscaper-cli targets create` subcommand put the content in a secret (which is referenced in the target) instead of in the target directly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `landscaper-cli targets create` subcommand now offers a `--secret` flag. When given together with a secret name, the command will create two manifests instead of one: one for a secret with the given name which contains the actual content, and one with a target which references this secret.
```
```other developer
The coding around the `targets create` subcommand has been refactored. The logic handling targets with secret references as well as the logic responsible for writing the output to a file instead of stdout have been extracted from the `kubernetes-cluster` subcommand and are now handled in a way which allows to add new target-type-specific subcommands without having to implement it again.
```
