### PR TITLE
fix default deployers

### DIFF
--- a/cmd/quickstart/install.go
+++ b/cmd/quickstart/install.go
@@ -262,15 +262,15 @@ func (o *installOptions) generateLandscaperValuesOverride() ([]byte, error) {
 	defaultDeployers := ""
 	if len(o.landscaperValues.Landscaper.Landscaper.Deployers) == 0 {
 		defaultDeployers = `
-  deployers:
-  - container
-  - helm
-  - manifest`
+    deployers:
+    - container
+    - helm
+    - manifest`
 	}
 
 	landscaperValuesOverride := fmt.Sprintf(`
-landscaper:%s
-  landscaper:
+landscaper:
+  landscaper:%s
     deployerManagement:
       namespace: %s
       agent:

--- a/cmd/quickstart/install_test.go
+++ b/cmd/quickstart/install_test.go
@@ -253,6 +253,10 @@ func TestGenerateLandscaperValuesOverride(t *testing.T) {
 	assert.True(t, ok)
 	data, ok = config.(map[string]interface{})
 	assert.True(t, ok)
+	config, ok = data["landscaper"]
+	assert.True(t, ok)
+	data, ok = config.(map[string]interface{})
+	assert.True(t, ok)
 	config, ok = data["deployers"]
 	assert.True(t, ok)
 	depList, ok := config.([]interface{})
@@ -266,6 +270,10 @@ func TestGenerateLandscaperValuesOverride(t *testing.T) {
 	data = map[string]interface{}{}
 	err = yaml.Unmarshal(lsvo, &data)
 	assert.NoError(t, err)
+	config, ok = data["landscaper"]
+	assert.True(t, ok)
+	data, ok = config.(map[string]interface{})
+	assert.True(t, ok)
 	config, ok = data["landscaper"]
 	assert.True(t, ok)
 	data, ok = config.(map[string]interface{})


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug in rendering the landscaper values overwrite when no deployers are specified.

/area ipcei
/area usability
/kind regression

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug in the `landscaper-cli quickstart install` subcommand which caused the default deployers (when no deployers are specified) to be inserted at the wrong position in the values overwrite file. This had the effect that the Landscaper would be deployed without any deployers, instead of using the default set as intended.
```
