### PR TITLE
update to golang 1.20.11 (run-int-tests)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -38,7 +38,7 @@ landscaper-cli:
     pull-request:
       steps:
         run_integration_test:
-          image: 'golang:1.20.10-alpine3.18'
+          image: 'golang:1.20.11-alpine3.18'
           execute:
           - "dev_integration_test"
           - "--target-clustername=lndscprcli-pr"
@@ -58,7 +58,7 @@ landscaper-cli:
     #       suppress_parallel_execution: true
     #   steps:
     #     run_integration_test:
-    #       image: 'golang:1.20.10-alpine3.18'
+    #       image: 'golang:1.20.11-alpine3.18'
     #       execute:
     #       - "dev_integration_test"
     #       - "--target-clustername=lndscprcli-cro"
@@ -66,7 +66,7 @@ landscaper-cli:
     release:
       steps:
         run_integration_test:
-          image: 'golang:1.20.10-alpine3.18'
+          image: 'golang:1.20.11-alpine3.18'
           execute:
           - "dev_integration_test"
           - "--target-clustername=lndscprcli-rel"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Update to golang 1.20.11 for removing CVE-2023-45283 & CVE-2023-45284
```
