### PR TITLE
Remove `snapshot_ctx_repository` attr from pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -20,8 +20,7 @@ landscaper-cli:
             - committers
             - codeowners
       component_descriptor:
-        ctx_repository: landscaper
-        snapshot_ctx_repository: landscaper
+        ocm_repository: landscaper
     steps:
       verify:
         image: 'golang:1.21'


### PR DESCRIPTION
This attribute will be removed with a future release of cc-utils. Hence, it must be removed from the pipeline definition as well. However, this will have no impact on the current functionality as the `ocm_repository` will be used as default for both "snapshot" and "non-snapshot" component descriptors.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
