### PR TITLE
Nix flake enablement for landscapercli

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -22,6 +22,7 @@ Files:
   Makefile
   README.md
   VERSION
+  flake.lock
 Copyright: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 License: Apache-2.0
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,52 @@ due to some fundamental API changes especially with respect to the handling of h
 
 ## Installation
 
-Installation instructions can be found [here](docs/installation.md).
+Install the latest release via [Nix](https://nixos.org), download binaries directly from [GitHub Releases](https://github.com/gardener/landscapercli/releases), or build and install directly from source.
+
+### Install using Nix (with [Flakes](https://nixos.wiki/wiki/Flakes))
+
+```bash
+# Nix (macOS, Linux, and Windows)
+# ad hoc cmd execution
+nix run github:gardener/landscapercli -- --help
+
+# install development version
+nix profile install github:gardener/landscapercli
+# or release <version>
+nix profile install github:gardener/landscapercli/<version>
+
+#check installation
+nix profile list | grep landscapercli
+
+# optionally, open a new shell and verify that cmd completion works
+landscaper-cli --help
+```
+
+### Install from Github Release
+
+If you install via GitHub releases, you need to
+
+- download the correct binary artifact for your os and architecture
+- unpack and put the `landscapercli` binary on your path
+
+You can use this boilerplate:
+```bash
+# set operating system and architecture
+os=darwin # choose between darwin, linux
+arch=amd64 # choose between amd64
+
+# Get latest version, unzip, make executable
+curl -LO "curl -LO https://github.com/gardener/landscapercli/releases/latest/download/landscapercli-${os}-${arch}.gz"
+gunzip landscapercli-${os}-${arch}.gz
+chmod +x ./landscapercli-${os}-${arch}
+
+# Move the binary in to your PATH
+sudo mv ./landscapercli-${os}-${arch} /usr/local/bin/landscaper-cli
+```
+
+### Build from source
+
+Instructions can be found [here](docs/installation.md).
 
 ## Documentation 
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705331948,
+        "narHash": "sha256-qjQXfvrAT1/RKDFAMdl8Hw3m4tLVvMCc8fMqzJv0pP4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b8dd8be3c790215716e7c12b247f45ca525867e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,114 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+{
+  description = "Nix flake for landscaper-cli";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    pname = "landscaper-cli";
+
+    # System types to support.
+    supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
+
+    # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+    # Nixpkgs instantiated for supported system types.
+    nixpkgsFor = forAllSystems (system: import nixpkgs {inherit system;});
+  in {
+    # Provide some binary packages for selected system types.
+    packages = forAllSystems (system: let
+      pkgs = nixpkgsFor.${system};
+      inherit (pkgs) stdenv lib;
+    in {
+      ${pname} = pkgs.buildGo121Module rec {
+        inherit pname self;
+        version-raw = lib.fileContents ./VERSION;
+        version = lib.elemAt (builtins.match "^[v]*([0-9|\.]*)[\-]*(.*)$" version-raw) 0;
+        COMPONENT_CLI_VERSION = lib.elemAt (builtins.match ".*component-cli ([v|0-9|\.]*).*" (lib.fileContents ./go.mod)) 0;
+        LANDSCAPER_VERSION = lib.elemAt (builtins.match ".*landscaper ([v|0-9|\.]*).*" (lib.fileContents ./go.mod)) 0;
+
+        gitCommit = if (self ? rev) then
+          self.rev
+        else
+          self.dirtyRev;
+        state = if (self ? rev) then
+          "clean"
+        else
+          "dirty";
+
+        # This vendorHash represents a dervative of all go.mod dependancies and needs to be adjusted with every change
+        # this project includes a vendor folder, so set = null
+        vendorHash = null;
+
+        src = ./.;
+
+        ldflags = [
+          "-s"
+          "-w"
+          "-X github.com/gardener/landscapercli/pkg/version.LandscaperCliVersion=${version-raw}"
+          "-X github.com/gardener/landscapercli/pkg/version.ComponentCliVersion=${COMPONENT_CLI_VERSION}"
+          "-X github.com/gardener/landscapercli/pkg/version.LandscaperGitVersion=${LANDSCAPER_VERSION}"
+          "-X github.com/gardener/landscapercli/pkg/version.LandscaperChartVersion=${LANDSCAPER_VERSION}"
+          "-X github.com/gardener/landscapercli/pkg/version.gitTreeState=${state}"
+          "-X github.com/gardener/landscapercli/pkg/version.gitCommit=${gitCommit}"
+        ];
+
+        CGO_ENABLED = 0;
+        # doCheck = false;
+        subPackages = [
+          "${pname}"
+        ];
+        nativeBuildInputs = [pkgs.installShellFiles];
+
+        postInstall = ''
+          installShellCompletion --cmd ${pname} \
+              --zsh  <($out/bin/${pname} completion zsh) \
+              --bash <($out/bin/${pname} completion bash) \
+              --fish <($out/bin/${pname} completion fish)
+        '';
+
+        meta = with lib; {
+          description = "The landscaper-cli interacts with Gardener Landscaper";
+          
+          longDescription = ''
+            The landscape-cli supports users to develop, maintain, and test components processed by the [Gardener Landscaper](https://github.com/gardener/landscaper).
+            This comprises the handling of objects like component descriptors, blueprints, installations, etc.
+            The cli integrates the commands of the [Components CLI](https://github.com/gardener/component-cli).
+          '';
+          homepage = "https://github.com/gardener/landscapercli";
+          license = licenses.asl20;
+          platforms = supportedSystems;
+        };
+      };
+    });
+
+    # Add dependencies that are only needed for development
+    devShells = forAllSystems (system: let
+      pkgs = nixpkgsFor.${system};
+    in {
+      default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          go_1_21   # golang 1.21
+          gopls     # go language server
+          gotools   # go imports
+          go-tools  # static checks
+          gnumake   # standard make
+        ];
+      };
+    });
+
+    # The default package for 'nix build'
+    defaultPackage = forAllSystems (system: self.packages.${system}.${pname});
+  };
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to enable landscapercli for the nix community.

```feature user
# with Nix (macOS, Linux, and Windows)
nix run github:gardener/landscapercli -- version

# development version
nix profile install github:gardener/landscapercli

landscaper-cli --help
```