### PR TITLE
Remove agent logic

### DIFF
--- a/.ci/dev_integration_test
+++ b/.ci/dev_integration_test
@@ -26,7 +26,7 @@ fi
 
 if ! command -v curl &> /dev/null
 then
-    apk add --no-cache --no-progress curl openssl
+    apk add --no-cache --no-progress curl openssl apache2-utils
 fi
 
 if ! command -v python3 &> /dev/null

--- a/cmd/quickstart/helper.go
+++ b/cmd/quickstart/helper.go
@@ -1,0 +1,83 @@
+package quickstart
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func removeObjects(ctx context.Context, k8sClient client.Client, crd *extv1.CustomResourceDefinition) error {
+	for k := range crd.Spec.Versions {
+		gvk := schema.GroupVersionKind{
+			Group:   crd.Spec.Group,
+			Version: crd.Spec.Versions[k].Name,
+			Kind:    crd.Spec.Names.Kind,
+		}
+
+		fmt.Printf("Removing objects of type %s\n", gvk)
+
+		objectList := &unstructured.UnstructuredList{}
+		objectList.SetGroupVersionKind(gvk)
+		if err := k8sClient.List(ctx, objectList); err != nil {
+			return err
+		}
+
+		for i := range objectList.Items {
+			item := &objectList.Items[i]
+			if err := removeObject(ctx, k8sClient, item); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func removeObject(ctx context.Context, k8sClient client.Client, object client.Object) error {
+	var err error
+
+	fmt.Printf("Removing object: %s\n", client.ObjectKeyFromObject(object).String())
+
+	for i := 0; i < 10; i++ {
+		if err = k8sClient.Get(ctx, client.ObjectKeyFromObject(object), object); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			fmt.Printf("Removing object: get failed: %s\n", err.Error())
+			continue
+		}
+
+		object.SetFinalizers(nil)
+		if err = k8sClient.Update(ctx, object); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			fmt.Printf("Removing object: update failed: %s\n", err.Error())
+			continue
+		}
+
+		if err = k8sClient.Delete(ctx, object); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+
+			fmt.Printf("Removing object: delete failed: %s\n", err.Error())
+			continue
+		}
+
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	if err != nil {
+		return err
+	} else {
+		return fmt.Errorf("object could not be removed %s", client.ObjectKeyFromObject(object).String())
+	}
+}

--- a/cmd/quickstart/install_test.go
+++ b/cmd/quickstart/install_test.go
@@ -261,23 +261,5 @@ func TestGenerateLandscaperValuesOverride(t *testing.T) {
 	assert.True(t, ok)
 	depList, ok := config.([]interface{})
 	assert.True(t, ok)
-	assert.EqualValues(t, []interface{}{"container", "helm", "manifest"}, depList)
-
-	// verify that deployers are not overwritten if specified
-	opts.landscaperValues.Landscaper.Landscaper.Deployers = []string{"mock"}
-	lsvo, err = opts.generateLandscaperValuesOverride()
-	assert.NoError(t, err)
-	data = map[string]interface{}{}
-	err = yaml.Unmarshal(lsvo, &data)
-	assert.NoError(t, err)
-	config, ok = data["landscaper"]
-	assert.True(t, ok)
-	data, ok = config.(map[string]interface{})
-	assert.True(t, ok)
-	config, ok = data["landscaper"]
-	assert.True(t, ok)
-	data, ok = config.(map[string]interface{})
-	assert.True(t, ok)
-	_, ok = data["deployers"]
-	assert.False(t, ok)
+	assert.EqualValues(t, []interface{}{}, depList)
 }

--- a/cmd/quickstart/quickstart.go
+++ b/cmd/quickstart/quickstart.go
@@ -5,6 +5,7 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/spf13/cobra"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -15,7 +16,9 @@ var (
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
+	_ = extv1.AddToScheme(scheme)
 	_ = lsv1alpha1.AddToScheme(scheme)
+
 }
 
 func NewQuickstartCommand(ctx context.Context) *cobra.Command {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/gardener/landscapercli/pkg/version"
 
@@ -37,7 +38,13 @@ func NewVersionCommand() *cobra.Command {
 				fmt.Printf("  Platform: %s\n", v.Platform)
 			}
 
-			fmt.Printf("\nCompatible Landscaper Version: %s", version.LandscaperGitVersion)
+			release, err := version.GetRelease()
+			if err != nil {
+				fmt.Println(err.Error())
+				os.Exit(1)
+			}
+
+			fmt.Printf("\nDefault Landscaper Version: %s", release)
 
 			fmt.Printf("\nCompatible and included Component-Cli Version: %s", version.ComponentCliVersion)
 			fmt.Printf("\n\n")

--- a/docs/commands/quickstart/install.md
+++ b/docs/commands/quickstart/install.md
@@ -23,25 +23,33 @@ If the installation succeeds you can verify the created pods with:
 
 ```
 kubectl get pods -n landscaper --kubeconfig=./kubconfig.yaml
-NAME                            READY   STATUS    RESTARTS   AGE
-container-default-container-deployer-7d7c5bf786-8lx9m   1/1     Running   0          2m15s
-helm-default-helm-deployer-555f848cd9-ltrq6             1/1     Running   0          2m10s
-landscaper-8658c96b59-qxj2g                             1/1     Running   0          2m41s
-landscaper-webhooks-589985ff45-kbm8r                    1/1     Running   0          2m41s
-manifest-default-manifest-deployer-7fbc77ff79-dklbr     1/1     Running   0          45s
+NAME                                  READY   STATUS    RESTARTS   AGE
+container-deployer-58c59cdcdd-thggs   1/1     Running   0          9s
+helm-deployer-66fc44f66b-h7262        1/1     Running   0          14s
+landscaper-6d4488d86f-fg5dg           1/1     Running   0          16s
+landscaper-main-c7d8c75db-ms2d7       1/1     Running   0          16s
+landscaper-webhooks-fbc6cd9bb-frhx5   1/1     Running   0          16s
+landscaper-webhooks-fbc6cd9bb-lgdgl   1/1     Running   0          16s
+manifest-deployer-db4466cc5-g99wm     1/1     Running   0          12s
 ```
 
 You see the central pods of the landscaper and its webhook as well as one pod for each deployer.  
 
-If you want to install the landscaper and the deployer in another namespace and/or provide some more configuration values,
-you might call the command in the following form:
+To install a specific version of the landscaper chart, use the `landscaper-chart-version` argument.
+
+If you want to install the landscaper and the deployer in another namespace use the `namespace` argument.
+
+The default settings for the installation of the Landscaper are usually sufficient. If you want to provide some 
+other configuration values, you might call the command in the following form:
 
 ```
-landscaper-cli quickstart install --kubeconfig ./kubconfig.yaml --landscaper-values ./landscaper-values.yaml --namespace landscaper
+landscaper-cli quickstart install --kubeconfig ./kubconfig.yaml --landscaper-values ./landscaper-values.yaml 
 ```
 
 `landscaper-values.yaml` is the values file of the landscaper. See [here](#landscaper-values) for a minimal example. 
-To install a specific version of the landscaper chart, use the `landscaper-chart-version` argument.
+In the `landscaper-values.yaml` it is not possible to configure any of the deployer, enable the Landscaper agent or
+deployer registration. The Landscaper agent and deployer configuration will be removed in the near future and 
+particular values files for the different deployer will be introduced later, if required.
 
 For more details on the cli usage, consult [landscaper-cli_quickstart_install reference](../../reference/landscaper-cli_quickstart_install.md).
 
@@ -112,7 +120,7 @@ This should give the output:
 
 indicating an empty registry.
 
-Afterwards, you can use the tools of your choice to push artifacts against the localhost:5000 registry url, e.g. 
+Afterward, you can use the tools of your choice to push artifacts against the localhost:5000 registry url, e.g. 
 
 TODO: verify special /etc/hosts domain name for docker push
 
@@ -127,15 +135,6 @@ landscaper:
   landscaper: 
     registryConfig: # contains optional oci secrets
       allowPlainHttpRegistries: false
-      secrets: {}
-#       <name>: <docker config json>
-
-    deployers:
-    - container
-    - helm
-    - manifest
-#   - mock
-
 ```
 
 

--- a/docs/commands/quickstart/uninstall.md
+++ b/docs/commands/quickstart/uninstall.md
@@ -1,6 +1,8 @@
 # Quickstart Install
 
-The `quickstart uninstall` command allows to uninstall the landscaper and OCI registry in a specified kubernetes cluster, such as a minikube, kind or garden shoot cluster. It is intended to be used to uninstall the landscaper and OCI registry from the `quickstart install` command.
+The `quickstart uninstall` command allows to uninstall the landscaper and OCI registry in a specified kubernetes cluster, 
+such as a minikube, kind or garden shoot cluster. It is intended to be used to uninstall the landscaper and OCI registry 
+from the `quickstart install` command.
 
 # Prerequisites
 - K8s cluster

--- a/docs/reference/landscaper-cli_quickstart_install.md
+++ b/docs/reference/landscaper-cli_quickstart_install.md
@@ -9,15 +9,19 @@ landscaper-cli quickstart install --kubeconfig [kubconfig.yaml] --landscaper-val
 ### Examples
 
 ```
+
+landscaper-cli quickstart install --kubeconfig ./kubconfig.yaml
+
 landscaper-cli quickstart install --kubeconfig ./kubconfig.yaml --landscaper-values ./landscaper-values.yaml --namespace landscaper --install-oci-registry --install-registry-ingress --registry-username testuser --registry-password some-pw
+
 ```
 
 ### Options
 
 ```
   -h, --help                              help for install
-      --install-oci-registry              install an OCI registry in the target cluster
-      --install-registry-ingress          install an ingress for accessing the OCI registry. 
+      --install-oci-registry              install an OCI registry in the target cluster (optional)
+      --install-registry-ingress          install an ingress for accessing the OCI registry (optional). 
                                           the credentials must be provided via the flags "--registry-username" and "--registry-password".
                                           the Landscaper instance will then be automatically configured with these credentials.
                                           prerequisites (!):
@@ -25,11 +29,11 @@ landscaper-cli quickstart install --kubeconfig ./kubconfig.yaml --landscaper-val
                                            - a nginx ingress controller must be deployed in the target cluster
                                            - the command "htpasswd" must be installed on your local machine
       --kubeconfig string                 path to the kubeconfig of the target cluster
-      --landscaper-chart-version string   use a custom Landscaper chart version (corresponds to Landscaper Github release with the same version number) (default "v0.93.0")
-      --landscaper-values string          path to values.yaml for the Landscaper Helm installation
-      --namespace string                  namespace where Landscaper and the OCI registry will get installed (default "landscaper")
-      --registry-password string          password for authenticating at the OCI registry
-      --registry-username string          username for authenticating at the OCI registry
+      --landscaper-chart-version string   use a custom Landscaper chart version (optional) (default "latest release")
+      --landscaper-values string          path to values.yaml for the Landscaper Helm installation (optional)
+      --namespace string                  namespace where Landscaper and the OCI registry will get installed (optional) (default "landscaper")
+      --registry-password string          password for authenticating at the OCI registry (optional)
+      --registry-username string          username for authenticating at the OCI registry (optional)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/landscaper-cli_quickstart_uninstall.md
+++ b/docs/reference/landscaper-cli_quickstart_uninstall.md
@@ -3,22 +3,23 @@
 command to uninstall Landscaper and OCI registry (from the install command) in a target cluster
 
 ```
-landscaper-cli quickstart uninstall --kubeconfig [kubconfig.yaml] --delete-namespace [flags]
+landscaper-cli quickstart uninstall --kubeconfig [kubconfig.yaml] --delete-namespace --delete-crd [flags]
 ```
 
 ### Examples
 
 ```
-landscaper-cli quickstart uninstall --kubeconfig ./kubconfig.yaml --namespace landscaper --delete-namespace
+landscaper-cli quickstart uninstall --kubeconfig ./kubconfig.yaml --namespace landscaper --delete-namespace --delete-crd
 ```
 
 ### Options
 
 ```
-      --delete-namespace    deletes the namespace (otherwise secrets, service accounts etc. of the landscaper installation in the namespace are not removed)
+      --delete-crd          deletes the Landscaper CRDs and all CRs of theses types without uninstalling the data deployed by them (optional, default false)
+      --delete-namespace    deletes the namespace (otherwise secrets, service accounts etc. of the landscaper installation in the namespace are not removed) (optional, default false)
   -h, --help                help for uninstall
       --kubeconfig string   path to the kubeconfig of the target cluster
-      --namespace string    namespace where Landscaper and the OCI registry are installed (default "landscaper")
+      --namespace string    namespace where Landscaper and the OCI registry are installed (optional) (default "landscaper")
 ```
 
 ### Options inherited from parent commands

--- a/flake.nix
+++ b/flake.nix
@@ -58,8 +58,6 @@ SPDX-License-Identifier: Apache-2.0
           "-w"
           "-X github.com/gardener/landscapercli/pkg/version.LandscaperCliVersion=${version-raw}"
           "-X github.com/gardener/landscapercli/pkg/version.ComponentCliVersion=${COMPONENT_CLI_VERSION}"
-          "-X github.com/gardener/landscapercli/pkg/version.LandscaperGitVersion=${LANDSCAPER_VERSION}"
-          "-X github.com/gardener/landscapercli/pkg/version.LandscaperChartVersion=${LANDSCAPER_VERSION}"
           "-X github.com/gardener/landscapercli/pkg/version.gitTreeState=${state}"
           "-X github.com/gardener/landscapercli/pkg/version.gitCommit=${gitCommit}"
         ];

--- a/hack/cross-build.sh
+++ b/hack/cross-build.sh
@@ -10,7 +10,6 @@ CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
 COMPONENT_CLI_VERSION=$(echo $COMPONENT_CLI_REF | awk '{print $2}')
-LANDSCAPER_VERSION=$(echo $LANDSCAPER_REF | awk '{print $2}')
 
 if [[ $EFFECTIVE_VERSION == "" ]]; then
   EFFECTIVE_VERSION=$(cat $PROJECT_ROOT/VERSION)
@@ -31,8 +30,6 @@ for i in "${build_matrix[@]}"; do
   -ldflags "-s -w \
             -X github.com/gardener/landscapercli/pkg/version.LandscaperCliVersion=$EFFECTIVE_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.ComponentCliVersion=$COMPONENT_CLI_VERSION \
-            -X github.com/gardener/landscapercli/pkg/version.LandscaperGitVersion=$LANDSCAPER_VERSION \
-            -X github.com/gardener/landscapercli/pkg/version.LandscaperChartVersion=$LANDSCAPER_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty) \
             -X github.com/gardener/landscapercli/pkg/version.gitCommit=$(git rev-parse --verify HEAD)" \
   ${PROJECT_ROOT}/landscaper-cli

--- a/hack/install-cli.sh
+++ b/hack/install-cli.sh
@@ -10,15 +10,12 @@ CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 
 COMPONENT_CLI_VERSION=$(echo $COMPONENT_CLI_REF | awk '{print $2}')
-LANDSCAPER_VERSION=$(echo $LANDSCAPER_REF | awk '{print $2}')
 GITTREESTATE=`([ -z "$(git status --porcelain 2>/dev/null)" ] && echo clean || echo dirty)`
 
 
 go install \
   -ldflags "-X github.com/gardener/landscapercli/pkg/version.LandscaperCliVersion=$EFFECTIVE_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.ComponentCliVersion=$COMPONENT_CLI_VERSION \
-            -X github.com/gardener/landscapercli/pkg/version.LandscaperGitVersion=$LANDSCAPER_VERSION \
-            -X github.com/gardener/landscapercli/pkg/version.LandscaperChartVersion=$LANDSCAPER_VERSION \
             -X github.com/gardener/landscapercli/pkg/version.gitTreeState=$GITTREESTATE \
             -X github.com/gardener/landscapercli/pkg/version.gitCommit=$(git rev-parse --verify HEAD)" \
   ${PROJECT_ROOT}/landscaper-cli

--- a/integration-test/util/config.go
+++ b/integration-test/util/config.go
@@ -3,10 +3,11 @@ package util
 import "time"
 
 type Config struct {
-	Kubeconfig          string
-	LandscaperNamespace string
-	TestNamespace       string
-	MaxRetries          int
-	SleepTime           time.Duration
-	RegistryBaseURL     string
+	Kubeconfig              string
+	LandscaperNamespace     string
+	TestNamespace           string
+	MaxRetries              int
+	SleepTime               time.Duration
+	RegistryBaseURL         string
+	ExternalRegistryBaseURL string
 }

--- a/integration-test/util/lscontext.go
+++ b/integration-test/util/lscontext.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DockerConfigJson struct {
+	Auths map[string]DockerConfigEntry `json:"auths"`
+}
+
+type DockerConfigEntry struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Email    string `json:"email,omitempty"`
+	Auth     string `json:"auth"`
+}
+
+func CreateContext(ctx context.Context, k8sClient client.Client, externalRegistryBaseURL, contextNamespace, contextName string) error {
+	auth := base64.StdEncoding.EncodeToString([]byte(Testuser + ":" + Testpw))
+	dockerConfigJson := DockerConfigJson{
+		Auths: map[string]DockerConfigEntry{
+			externalRegistryBaseURL: {
+				Username: Testuser,
+				Password: Testpw,
+				Email:    "test@test.com",
+				Auth:     auth,
+			},
+		},
+	}
+
+	dockerConfigJsonBytes, _ := json.Marshal(dockerConfigJson)
+	dockerConfigJsonString := string(dockerConfigJsonBytes)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      contextName,
+			Namespace: contextNamespace,
+		},
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(dockerConfigJsonString),
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+	}
+
+	err := k8sClient.Create(ctx, secret)
+	if err != nil {
+		return err
+	}
+
+	repoCtx := &cdv2.UnstructuredTypedObject{}
+	repoCtx.UnmarshalJSON([]byte(fmt.Sprintf(`{"type": "OCIRegistry", "baseUrl": "%s"}`, externalRegistryBaseURL)))
+	lscontext := &lsv1alpha1.Context{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      contextName,
+			Namespace: contextNamespace,
+		},
+		ContextConfiguration: lsv1alpha1.ContextConfiguration{
+			RegistryPullSecrets: []corev1.LocalObjectReference{corev1.LocalObjectReference{
+				Name: contextName,
+			}},
+			RepositoryContext: repoCtx,
+			UseOCM:            true,
+		},
+	}
+
+	err = k8sClient.Create(ctx, lscontext)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/integration-test/util/util.go
+++ b/integration-test/util/util.go
@@ -3,9 +3,21 @@ package util
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/uuid"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/stretchr/testify/assert"
 )
+
+const (
+	Testuser = "testuser"
+)
+
+var Testpw string
+
+func init() {
+	Testpw = string(uuid.NewUUID())
+}
 
 // DummyTestingT is a utility struct for using assertions from "github.com/stretchr/testify/assert"
 // in the integration tests (outside of unit tests)

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -1,0 +1,32 @@
+package version
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+type Release struct {
+	TagName string `json:"tag_name"`
+}
+
+func GetRelease() (string, error) {
+	resp, err := http.Get("https://api.github.com/repos/gardener/landscaper/releases/latest")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var release Release
+	err = json.Unmarshal(body, &release)
+	if err != nil {
+		return "", err
+	}
+
+	return release.TagName, err
+}

--- a/pkg/version/version_info.go
+++ b/pkg/version/version_info.go
@@ -1,8 +1,6 @@
 package version
 
 var (
-	LandscaperCliVersion   = ""
-	LandscaperGitVersion   = "v0.93.0"
-	LandscaperChartVersion = "v0.93.0"
-	ComponentCliVersion    = ""
+	LandscaperCliVersion = ""
+	ComponentCliVersion  = ""
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Modify the quickstart install/uninstall commands such that the Landscaper agent logic including the deployer registration is not used anymore. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
- remove dependency to Landscaper agent logic
- install latest Landscaper release as default
- flag remove-crds to remove all CRDs and CRs of landscaper types
- no configuration yaml required for installation 
```
