### PR TITLE
Fix nilpointer in inspect command

### DIFF
--- a/cmd/installations/inspect/transformer.go
+++ b/cmd/installations/inspect/transformer.go
@@ -70,7 +70,7 @@ func (t *Transformer) transformInstallation(installationTree *InstallationTree, 
 	if t.wideMode {
 		wide := strings.Builder{}
 		cd := "inline"
-		if installationTree.Installation.Spec.ComponentDescriptor.Reference != nil {
+		if installationTree.Installation.Spec.ComponentDescriptor != nil && installationTree.Installation.Spec.ComponentDescriptor.Reference != nil {
 			cd = fmt.Sprintf("%s:%s", installationTree.Installation.Spec.ComponentDescriptor.Reference.ComponentName, installationTree.Installation.Spec.ComponentDescriptor.Reference.Version)
 		}
 		wide.WriteString(fmt.Sprintf("Component Descriptor: %s\n", cd))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the following bug:
The command `landscaper-cli installation inspect` fails with a nilpointer in the following situation:
- the installation has no component descriptor &mdash; this is typically the case if it has an inline blueprint,
- and if the command is called with the option `-o wide` (or `--owide` or `-w`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Fix for a nilpointer in the inspect command when executed with option "-o wide"
```
