### PR TITLE
Build executable for windows amd64 architecture

### DIFF
--- a/hack/cross-build.sh
+++ b/hack/cross-build.sh
@@ -16,7 +16,7 @@ fi
   cd "$PROJECT_ROOT"
   mkdir -p dist
 
-  build_matrix=("linux,amd64" "darwin,amd64" "darwin,arm64")
+  build_matrix=("linux,amd64" "darwin,amd64" "darwin,arm64", "windows,amd64")
 
   for i in "${build_matrix[@]}"; do
     IFS=',' read os arch <<< "${i}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Build executable for windows amd64 architecture.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Executable for windows amd64 architecture
```
