### PR TITLE
Improve error messages when reading latest landscaper version fails

### DIFF
--- a/cmd/quickstart/install.go
+++ b/cmd/quickstart/install.go
@@ -193,7 +193,7 @@ func (o *installOptions) run(ctx context.Context, log logr.Logger) error {
 	if version == latestRelease {
 		version, err = version2.GetRelease()
 		if err != nil {
-			return fmt.Errorf("cannot get latest Landscaper release: %w", err)
+			return err
 		}
 	}
 

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 )
@@ -13,19 +14,23 @@ type Release struct {
 func GetRelease() (string, error) {
 	resp, err := http.Get("https://api.github.com/repos/gardener/landscaper/releases/latest")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get latest landscaper release info: request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get latest landscaper release info: read failed: %w", err)
 	}
 
 	var release Release
 	err = json.Unmarshal(body, &release)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get latest landscaper release info: unmarshal failed: %w", err)
+	}
+
+	if release.TagName == "" {
+		return "", fmt.Errorf("failed to get latest landscaper release info: no tag")
 	}
 
 	return release.TagName, err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improve the error messages when reading the latest landscaper version fails.
In particular, we will see an error if the response of https://api.github.com/repos/gardener/landscaper/releases/latest contains no `tag_name`. 

**Which issue(s) this PR fixes**:
Fixes #374 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Improved error handling of the quickstart install command.
```
