### PR TITLE
Fix component build

### DIFF
--- a/.landscaper/components.yaml
+++ b/.landscaper/components.yaml
@@ -9,7 +9,6 @@ components:
         version: ${VERSION}
         access:
           type: github
-          commit: ${COMMIT_SHA}
           ref: refs/tags/${VERSION}
           repoUrl: github.com/gardener/landscapercli
     componentReferences: []

--- a/hack/build-component.sh
+++ b/hack/build-component.sh
@@ -25,5 +25,4 @@ fi
 echo "> Building component in version $CDVERSION"
 $OCM add componentversions --file "$PROJECT_ROOT/components" --version "$CDVERSION" --create --force "$PROJECT_ROOT/.landscaper/components.yaml" -- \
   CDVERSION="$CDVERSION" \
-  VERSION="$VERSION" \
-  COMMIT_SHA="$(git rev-parse HEAD)"
+  VERSION="$VERSION"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the build of the landscaper-cli component.

According to [Access Method gitHub and github - Github Commit Access](https://github.com/open-component-model/ocm/tree/main/api/ocm/extensions/accessmethods/github), for the OCM access type `gitHub`, the fields `ref` and `commit` are mutually exclusive. 

Currently, in `.landscaper/component.yaml` both fields were set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
