### PR TITLE
feat: add `linux/arm64` build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install-cli: ## Installs the CLI.
 	@EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) $(REPO_ROOT)/hack/install-cli.sh
 
 .PHONY: cross-build
-cross-build: ## Builds the binary for linux/amd64, darwin/amd64, and darwin/arm64.
+cross-build: ## Builds the binary for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64.
 	@EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) $(REPO_ROOT)/hack/cross-build.sh
 
 .PHONY: component

--- a/hack/cross-build.sh
+++ b/hack/cross-build.sh
@@ -16,7 +16,7 @@ fi
   cd "$PROJECT_ROOT"
   mkdir -p dist
 
-  build_matrix=("linux,amd64" "darwin,amd64" "darwin,arm64", "windows,amd64")
+  build_matrix=("linux,amd64" "linux,arm64" "darwin,amd64" "darwin,arm64", "windows,amd64")
 
   for i in "${build_matrix[@]}"; do
     IFS=',' read os arch <<< "${i}"


### PR DESCRIPTION
**What this PR does / why we need it**: 
This PR adds the `linux/arm64` build target to `cross-build.sh`, bringing parity with the existing `darwin/arm64` releases. Having pre-built `linux/arm64` binaries simplifies running the project in Docker, for example.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**: 
Verified locally on an M-series Mac. Will adding this target automatically include the `linux/arm64` binary in GitHub Releases, or are additional release-pipeline changes required?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Adds the linux/arm64 target to the cross-build.sh script
```
